### PR TITLE
feat(timeline): toggle + threshold for stacked-lane sessions

### DIFF
--- a/Piru/Localizable.xcstrings
+++ b/Piru/Localizable.xcstrings
@@ -23287,6 +23287,38 @@
         }
       }
     },
+    "Stack Busy Sessions" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拆分繁忙记录图表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拆分繁忙記錄圖表"
+          }
+        }
+      }
+    },
+    "Stack From" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拆分阈值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拆分閾值"
+          }
+        }
+      }
+    },
     "Stack Redoses" : {
       "localizations" : {
         "zh-Hans" : {
@@ -26440,6 +26472,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "時間"
+          }
+        }
+      }
+    },
+    "When a session reaches this many different substances, the timeline splits overlapping curves into separate stacked lanes — one per substance — so a busy session stays readable. When off, every curve is always overlaid on one graph." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当某次记录达到这么多种不同物质时，时间线会将重叠的曲线拆分为独立的堆叠泳道——每种物质一条——让繁忙的记录依然清晰可读。关闭后，所有曲线始终叠加在同一张图上。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當某次記錄達到這麼多種不同物質時，時間線會將重疊的曲線拆分為獨立的堆疊泳道——每種物質一條——讓繁忙的記錄依然清晰可讀。關閉後，所有曲線始終疊加在同一張圖上。"
           }
         }
       }

--- a/Piru/Views/EntryListView.swift
+++ b/Piru/Views/EntryListView.swift
@@ -1011,6 +1011,8 @@ private struct ActiveSessionHeroCard: View {
     var onTap: () -> Void
 
     @AppStorage("stackRedoses", store: UserDefaults(suiteName: "group.dev.yumeji.piru")) private var stackRedoses = true
+    @AppStorage(LaneModeDefaults.enabledKey, store: UserDefaults(suiteName: LaneModeDefaults.suite)) private var laneModeEnabled = LaneModeDefaults.enabledDefault
+    @AppStorage(LaneModeDefaults.thresholdKey, store: UserDefaults(suiteName: LaneModeDefaults.suite)) private var laneModeThreshold = LaneModeDefaults.thresholdDefault
 
     private var isSingleDose: Bool {
         states.count == 1
@@ -1223,7 +1225,7 @@ private struct ActiveSessionHeroCard: View {
 
     private var multiGraphHeight: CGFloat {
         let base = GraphMetrics.embedded
-        guard distinctCount >= TimelineGraphView.laneModeThreshold else { return base }
+        guard laneModeEnabled, distinctCount >= laneModeThreshold else { return base }
         let ideal = CGFloat(distinctCount) * 32 + 40
         return max(base, min(ideal, 380))
     }

--- a/Piru/Views/SessionDetailView.swift
+++ b/Piru/Views/SessionDetailView.swift
@@ -21,6 +21,8 @@ struct SessionDetailView: View {
         session.startDate
     }
     @AppStorage("stackRedoses", store: UserDefaults(suiteName: "group.dev.yumeji.piru")) private var stackRedoses = true
+    @AppStorage(LaneModeDefaults.enabledKey, store: UserDefaults(suiteName: LaneModeDefaults.suite)) private var laneModeEnabled = LaneModeDefaults.enabledDefault
+    @AppStorage(LaneModeDefaults.thresholdKey, store: UserDefaults(suiteName: LaneModeDefaults.suite)) private var laneModeThreshold = LaneModeDefaults.thresholdDefault
 
     /// The session immediately before this one in time — the target for
     /// "Merge with previous".
@@ -84,7 +86,7 @@ struct SessionDetailView: View {
     /// a very busy day still fits a scrollable card.
     private func graphHeight(enlarged: Bool) -> CGFloat {
         let base = enlarged ? Self.enlargedGraphHeight : GraphMetrics.embedded
-        guard laneCount >= TimelineGraphView.laneModeThreshold else { return base }
+        guard laneModeEnabled, laneCount >= laneModeThreshold else { return base }
         let perLane: CGFloat = enlarged ? 46 : 32
         let axisOverhead: CGFloat = 40
         let ideal = CGFloat(laneCount) * perLane + axisOverhead

--- a/Piru/Views/SettingsView.swift
+++ b/Piru/Views/SettingsView.swift
@@ -230,6 +230,8 @@ struct NotificationSettingsView: View {
 /// Day-grouping, timeline, and quick-log preferences.
 struct JournalSettingsView: View {
     @AppStorage("stackRedoses", store: UserDefaults(suiteName: "group.dev.yumeji.piru")) private var stackRedoses = true
+    @AppStorage(LaneModeDefaults.enabledKey, store: UserDefaults(suiteName: LaneModeDefaults.suite)) private var stackedLanesEnabled = LaneModeDefaults.enabledDefault
+    @AppStorage(LaneModeDefaults.thresholdKey, store: UserDefaults(suiteName: LaneModeDefaults.suite)) private var laneModeThreshold = LaneModeDefaults.thresholdDefault
     @AppStorage(QuickLogManager.fixedOrderDefaultsKey) private var quickLogFixedOrder = false
     @AppStorage(Calendar.dayBoundaryHourKey, store: UserDefaults(suiteName: "group.dev.yumeji.piru")) private var dayBoundaryHour = 4
 
@@ -258,6 +260,26 @@ struct JournalSettingsView: View {
                     .tint(Theme.accent)
                 } footer: {
                     Text("Combine repeat doses of the same substance into a single curve, where each redose adds to the combined intensity. When off, each dose is drawn as its own line.")
+                }
+
+                Section {
+                    Toggle(isOn: $stackedLanesEnabled) {
+                        Label("Stack Busy Sessions", systemImage: "square.stack.3d.up")
+                    }
+                    .tint(Theme.accent)
+
+                    if stackedLanesEnabled {
+                        Stepper(value: $laneModeThreshold, in: LaneModeDefaults.thresholdRange) {
+                            HStack {
+                                Text("Stack From")
+                                Spacer()
+                                Text(laneModeThreshold, format: .number)
+                                    .foregroundStyle(Theme.secondaryLabel)
+                            }
+                        }
+                    }
+                } footer: {
+                    Text("When a session reaches this many different substances, the timeline splits overlapping curves into separate stacked lanes — one per substance — so a busy session stays readable. When off, every curve is always overlaid on one graph.")
                 }
 
                 Section {

--- a/Shared/TimelineGraphView.swift
+++ b/Shared/TimelineGraphView.swift
@@ -20,6 +20,21 @@ enum GraphMetrics {
     static let embedded: CGFloat = 168
 }
 
+/// UserDefaults keys, defaults, and bounds for the lane-mode ("small multiples")
+/// preference. One source of truth so the Settings UI, the host views that size
+/// the graph card, and the graph's own gate all agree. Stored in the app group
+/// suite so the widget/Live Activity honor the same choice as the main app.
+enum LaneModeDefaults {
+    static let suite = "group.dev.yumeji.piru"
+    static let enabledKey = "stackedLanesEnabled"
+    static let thresholdKey = "laneModeThreshold"
+    static let enabledDefault = true
+    static let thresholdDefault = 4
+    /// Allowed stepper range — needs ≥2 distinct substances before lanes mean
+    /// anything, and beyond ~8 the day is busy by any measure.
+    static let thresholdRange = 2 ... 8
+}
+
 /// A dose without duration data, shown as a timestamp marker on the graph.
 struct DoseMarker: Hashable {
     let substanceName: String
@@ -368,11 +383,16 @@ struct TimelineGraphView: View, Equatable {
         return substances.isEmpty || markers.count <= Self.maxCompactMarkers
     }
 
-    /// At or above this many distinct substances, overlapping translucent fills
-    /// stop conveying information and collapse into curve soup — so a day this
-    /// busy renders as stacked per-substance lanes (small multiples) instead.
-    /// Internal so hosts can size the graph to keep each lane readable.
-    static let laneModeThreshold: Int = 4
+    /// Whether stacked lanes are used at all (user-toggleable). When off, busy
+    /// days always overlay every curve on one graph regardless of substance count.
+    @AppStorage(LaneModeDefaults.enabledKey, store: UserDefaults(suiteName: LaneModeDefaults.suite))
+    private var laneModeEnabled = LaneModeDefaults.enabledDefault
+
+    /// Distinct-substance count at or above which overlapping translucent fills
+    /// collapse into curve soup, so the day renders as stacked per-substance
+    /// lanes (small multiples) instead. User-configurable.
+    @AppStorage(LaneModeDefaults.thresholdKey, store: UserDefaults(suiteName: LaneModeDefaults.suite))
+    private var laneModeThreshold = LaneModeDefaults.thresholdDefault
 
     /// Distinct substances drawn on the graph (by lowercased name).
     private var distinctSubstanceCount: Int {
@@ -381,9 +401,10 @@ struct TimelineGraphView: View, Equatable {
 
     /// Switch a busy day from overlapping curves to stacked lanes. Gated to the
     /// roomy day surfaces (`dayBounded`, non-compact) — thumbnails stay a glance
-    /// of texture, and the live accessory keeps its single-baseline look.
+    /// of texture, and the live accessory keeps its single-baseline look — and to
+    /// the user's lane-mode preference.
     private var laneMode: Bool {
-        !compact && dayBounded && distinctSubstanceCount >= Self.laneModeThreshold
+        laneModeEnabled && !compact && dayBounded && distinctSubstanceCount >= laneModeThreshold
     }
 
     /// One lane per distinct substance, in first-dose order, carrying every dose

--- a/translate_catalog.py
+++ b/translate_catalog.py
@@ -2364,6 +2364,13 @@ T = {
         "預設調色盤中已有此顏色",
     ),
     "You've already created this shade": ("你已创建过此颜色", "你已建立過此顏色"),
+    # 2026-06 — stacked-lane (small multiples) timeline preference
+    "Stack Busy Sessions": ("拆分繁忙记录图表", "拆分繁忙記錄圖表"),
+    "Stack From": ("拆分阈值", "拆分閾值"),
+    "When a session reaches this many different substances, the timeline splits overlapping curves into separate stacked lanes — one per substance — so a busy session stays readable. When off, every curve is always overlaid on one graph.": (
+        "当某次记录达到这么多种不同物质时，时间线会将重叠的曲线拆分为独立的堆叠泳道——每种物质一条——让繁忙的记录依然清晰可读。关闭后，所有曲线始终叠加在同一张图上。",
+        "當某次記錄達到這麼多種不同物質時，時間線會將重疊的曲線拆分為獨立的堆疊泳道——每種物質一條——讓繁忙的記錄依然清晰可讀。關閉後，所有曲線始終疊加在同一張圖上。",
+    ),
 }
 
 # Widget translations
@@ -2535,7 +2542,7 @@ except ImportError:
     pass
 
 if __name__ == "__main__":
-    project_root = Path("/Users/kirie/Developer/piru")
+    project_root = Path(__file__).resolve().parent
 
     # Brand-new strings added from the CLI that Xcode hasn't extracted into the
     # catalog yet. List them here so they get inserted; clear once Xcode has
@@ -2821,6 +2828,10 @@ if __name__ == "__main__":
         "LogD",
         "TPSA",
         "pKa",
+        # Stacked-lane timeline preference 2026-06
+        "Stack Busy Sessions",
+        "Stack From",
+        "When a session reaches this many different substances, the timeline splits overlapping curves into separate stacked lanes — one per substance — so a busy session stays readable. When off, every curve is always overlaid on one graph.",
     }
 
     print("--- Piru main app catalog ---")


### PR DESCRIPTION
## Summary

The timeline switched a busy session from overlapping curves to stacked per-substance lanes ("small multiples") at a **hardcoded 4 distinct substances**, with no way to disable it or tune the cutoff. This adds two user preferences under **Settings → Journal**:

- **Stack Busy Sessions** — master toggle for whether stacked lanes are ever used. When off, every curve is always overlaid on one graph regardless of substance count.
- **Stack From** — stepper (range 2–8) for how many distinct substances trigger lanes. Shown only when the toggle is on; value rendered as a bare number.

Both prefs are stored in the app-group suite (`group.dev.yumeji.piru`) so the widget / Live Activity honor the same choice as the main app.

## Implementation notes

- New `LaneModeDefaults` enum in `Shared/TimelineGraphView.swift` is the single source of truth for the keys, defaults, and stepper range.
- `TimelineGraphView.laneMode` now gates on the live values via `@AppStorage` (lane mode is presentation-only, so it stays out of the curve-geometry cache key `DerivedKey`).
- The two host views that size their graph card by the threshold — `SessionDetailView.graphHeight` and `ActiveSessionHeroCard.multiGraphHeight` — read the same prefs, so card height and the graph's lane decision can't disagree.

## Localization

- Added en / zh-Hans / zh-Hant for the 3 new strings via `translate_catalog.py` (session terminology matches the app's existing 记录 / 記錄).
- The threshold readout uses `Text(_, format: .number)`, so it localizes for free and adds no catalog key.
- Also fixed `translate_catalog.py`'s stale hardcoded `project_root` to resolve relative to the script file.

## Testing

- `xcodebuild -scheme Piru -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` — **BUILD SUCCEEDED** across all targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)