### PR TITLE
feat(inventory): substance inventory tracking (derived stock)

### DIFF
--- a/Piru/Data/InventoryService.swift
+++ b/Piru/Data/InventoryService.swift
@@ -1,0 +1,281 @@
+import Foundation
+import SwiftData
+
+// MARK: - InventoryMath (pure derivation)
+
+/// The read side of inventory: turns an ``InventoryItem``'s embedded manual
+/// events plus the `DoseEntry` log into the current amount on hand and the
+/// derived "doses left" / run-out estimates.
+///
+/// Everything here is a fresh projection of persisted rows — there is no stored
+/// running tally — so editing or deleting a dose is reflected on the next read
+/// with no sync code, and imported doses count exactly like typed ones.
+@MainActor
+enum InventoryMath {
+    /// Rolling-window run-out estimate for an item.
+    struct RunOut: Equatable {
+        /// Average consumption per day over the last 7 days, in the item's unit.
+        let dailyAvg: Double
+        /// Estimated days until the current stock reaches zero at ``dailyAvg``.
+        let daysLeft: Double
+    }
+
+    /// All doses that count against this item: matching substance (case-
+    /// insensitive) and salt (strict, `nil == nil`), on or after `trackingStart`.
+    ///
+    /// We fetch by the `timestamp` predicate, then filter substance/salt in
+    /// memory — a case-insensitive compare and a nil-safe `saltForm` match aren't
+    /// expressible cleanly in `#Predicate`, and the per-item volume is small.
+    static func doses(for item: InventoryItem, in ctx: ModelContext) -> [DoseEntry] {
+        let start = item.trackingStart
+        let lowered = item.substance.lowercased()
+        let all = (try? ctx.fetch(FetchDescriptor<DoseEntry>(
+            predicate: #Predicate { $0.timestamp >= start }))) ?? []
+        return all.filter {
+            $0.substance.lowercased() == lowered && $0.saltForm == item.saltForm
+        }
+    }
+
+    /// Convert a dose amount into the item's unit. Delegates to the existing
+    /// mass-family conversion (µg ↔ mg ↔ g), which also returns the amount
+    /// unchanged for an exact-unit match (mL→mL, caps→caps). Anything else
+    /// (mg vs mL, IU, drops) returns `nil` → that dose is skipped, never blocked.
+    static func convert(_ amount: Double, from: String, to: String) -> Double? {
+        DoseUnit.convert(amount, from: from, to: to)
+    }
+
+    /// Stock = replay(manual events ∪ converted doses), floored at 0 on the way
+    /// down. Restocks/initial add; adjustments and consumption floor at 0 so an
+    /// overdraw is forgiven (30 − log 50 → 0; a later +100 → 100).
+    static func quantity(for item: InventoryItem, in ctx: ModelContext) -> Double {
+        struct Tick { let date: Date; let delta: Double; let floors: Bool }
+        var ticks: [Tick] = item.manualEvents.map {
+            Tick(date: $0.date, delta: $0.amount, floors: $0.kind == .adjustment)
+        }
+        for dose in doses(for: item, in: ctx) {
+            guard let converted = convert(dose.amount, from: dose.unit, to: item.unit) else { continue }
+            ticks.append(Tick(date: dose.timestamp, delta: -converted, floors: true))
+        }
+        var balance = 0.0
+        for tick in ticks.sorted(by: { $0.date < $1.date }) {
+            balance = tick.floors ? max(0, balance + tick.delta) : balance + tick.delta
+        }
+        return balance
+    }
+
+    /// Whole doses remaining, only when a `doseSize` is set/non-zero.
+    /// Reads the cached ``InventoryItem/currentQuantity``.
+    static func dosesLeft(for item: InventoryItem) -> Int? {
+        guard let size = item.doseSize, size > 0 else { return nil }
+        return Int((item.currentQuantity / size).rounded(.down))
+    }
+
+    /// Run-out estimate from a rolling 7-day average, gated so it only shows for a
+    /// daily / semi-daily pattern (≥5 of the last 7 calendar days had a matching
+    /// dose). Returns `nil` when the guard fails — never a fabricated estimate.
+    ///
+    /// `daysLeft` is computed from the cached ``InventoryItem/currentQuantity``,
+    /// per the spec; callers refresh the cache (`recompute`) before display.
+    static func runOut(for item: InventoryItem, in ctx: ModelContext, now: Date = .now) -> RunOut? {
+        let calendar = Calendar.current
+        guard let weekAgo = calendar.date(byAdding: .day, value: -7, to: now) else { return nil }
+        let recent = doses(for: item, in: ctx).filter { $0.timestamp >= weekAgo && $0.timestamp <= now }
+        let daysWithADose = Set(recent.map { calendar.startOfDay(for: $0.timestamp) }).count
+        guard daysWithADose >= 5 else { return nil }
+        let consumed = recent.reduce(0.0) { sum, dose in
+            sum + (convert(dose.amount, from: dose.unit, to: item.unit) ?? 0)
+        }
+        let dailyAvg = consumed / 7
+        guard dailyAvg > 0 else { return nil }
+        return RunOut(dailyAvg: dailyAvg, daysLeft: item.currentQuantity / dailyAvg)
+    }
+}
+
+// MARK: - InventoryService (mutations + cache refresh)
+
+/// The write side of inventory: stateless mutations that append ``ManualEvent``s,
+/// refresh the ``InventoryItem/currentQuantity`` cache, and manage the baseline
+/// and low-stock flag. Notification *scheduling* is wired separately
+/// (`DoseNotificationManager`, Phase 2); this type only keeps the de-dupe flag
+/// honest so a future dip re-fires.
+@MainActor
+enum InventoryService {
+    /// Existing tracked item for a `(substance, salt)` pair, if any.
+    static func find(substance: String, saltForm: String?, in ctx: ModelContext) -> InventoryItem? {
+        let lowered = substance.lowercased()
+        let all = (try? ctx.fetch(FetchDescriptor<InventoryItem>())) ?? []
+        return all.first { $0.substance.lowercased() == lowered && $0.saltForm == saltForm }
+    }
+
+    /// Start tracking a substance with an optional initial amount. With
+    /// `setBaseline: true`, pins the post-event total as the baseline (100%).
+    @discardableResult
+    static func create(
+        substance: String,
+        saltForm: String?,
+        unit: String,
+        initial: Double,
+        threshold: Double?,
+        setBaseline: Bool,
+        in ctx: ModelContext,
+    ) -> InventoryItem {
+        var events: [ManualEvent] = []
+        if initial != 0 {
+            events.append(ManualEvent(kind: .initial, amount: initial, date: .now, setsBaseline: setBaseline))
+        }
+        let item = InventoryItem(
+            substance: substance,
+            saltForm: saltForm,
+            unit: unit,
+            trackingStart: .now,
+            lowStockThreshold: normalizedPositive(threshold),
+            manualEvents: events,
+        )
+        ctx.insert(item)
+        ensureColor(for: item.substance, in: ctx)
+        recompute(item, in: ctx)
+        if setBaseline { item.baselineQuantity = normalizedPositive(item.currentQuantity) }
+        return item
+    }
+
+    /// Add stock. With `setBaseline: true`, captures the post-restock total as the
+    /// new baseline and tags the event's provenance.
+    static func restock(
+        _ item: InventoryItem,
+        amount: Double,
+        note: String?,
+        setBaseline: Bool,
+        in ctx: ModelContext,
+    ) {
+        var events = item.manualEvents
+        events.append(ManualEvent(
+            kind: .restock, amount: amount, date: .now, note: note, setsBaseline: setBaseline,
+        ))
+        item.manualEvents = events
+        recompute(item, in: ctx)
+        if setBaseline { item.baselineQuantity = normalizedPositive(item.currentQuantity) }
+    }
+
+    /// Set the exact amount on hand (recount / spill) by appending a signed
+    /// adjustment that lands the live quantity on `exact`.
+    static func correctTo(_ item: InventoryItem, exact: Double, note: String?, in ctx: ModelContext) {
+        let current = InventoryMath.quantity(for: item, in: ctx)
+        let delta = exact - current
+        var events = item.manualEvents
+        events.append(ManualEvent(kind: .adjustment, amount: delta, date: .now, note: note))
+        item.manualEvents = events
+        recompute(item, in: ctx)
+    }
+
+    /// Set the supply-bar baseline directly (Edit screen). `nil`, `0`, or a
+    /// negative value disables the bar.
+    static func setBaseline(_ item: InventoryItem, value: Double?, in ctx: ModelContext) {
+        item.baselineQuantity = normalizedPositive(value)
+    }
+
+    /// Set the optional "single dose" size powering "~N doses left".
+    /// `nil`, `0`, or negative disables it.
+    static func setDoseSize(_ item: InventoryItem, value: Double?) {
+        item.doseSize = normalizedPositive(value)
+    }
+
+    /// Change the item's base unit, converting everything denominated in it.
+    ///
+    /// The spec calls out converting `baselineQuantity`, `lowStockThreshold`, and
+    /// `doseSize` within the mass family (clearing them when the new unit isn't
+    /// convertible). The manual-event amounts are *also* stored in the item's
+    /// unit, so they must convert too — otherwise the replayed stock would silently
+    /// read old-unit numbers as new-unit ones. If the units aren't convertible we
+    /// leave the raw event amounts in place and clear the three derived fields,
+    /// matching the spec's "user re-sets on next edit" intent.
+    static func changeUnit(_ item: InventoryItem, to newUnit: String, in ctx: ModelContext) {
+        let oldUnit = item.unit
+        guard oldUnit != newUnit else { return }
+
+        let factor = InventoryMath.convert(1, from: oldUnit, to: newUnit)
+        if let factor {
+            item.manualEvents = item.manualEvents.map { event in
+                var converted = event
+                converted.amount = event.amount * factor
+                return converted
+            }
+            item.baselineQuantity = item.baselineQuantity.map { $0 * factor }
+            item.lowStockThreshold = item.lowStockThreshold.map { $0 * factor }
+            item.doseSize = item.doseSize.map { $0 * factor }
+        } else {
+            // Not convertible: keep raw event amounts, clear the derived fields.
+            item.baselineQuantity = nil
+            item.lowStockThreshold = nil
+            item.doseSize = nil
+        }
+        item.unit = newUnit
+        recompute(item, in: ctx)
+    }
+
+    /// Refresh the denormalized cache from the derived quantity, then evaluate
+    /// the low-stock threshold. Pass `notify: false` to update the cache and the
+    /// de-dupe flag *without* firing a notification — used by bulk import/restore
+    /// so a restored backup doesn't spray one alert per low item.
+    static func recompute(_ item: InventoryItem, in ctx: ModelContext, notify: Bool = true) {
+        item.currentQuantity = InventoryMath.quantity(for: item, in: ctx)
+        evaluateLowStock(item, notify: notify)
+    }
+
+    /// Refresh every tracked item's cache — used after a bulk insert (import /
+    /// restore) and alongside the existing post-log widget reload.
+    static func recomputeAll(in ctx: ModelContext, notify: Bool = true) {
+        let items = (try? ctx.fetch(FetchDescriptor<InventoryItem>())) ?? []
+        for item in items { recompute(item, in: ctx, notify: notify) }
+    }
+
+    // MARK: - Helpers
+
+    /// Fire the low-stock alert at most once per dip, and reset the de-dupe flag
+    /// once stock rises back above the threshold so a later dip re-fires.
+    ///
+    /// The flag is set whenever the item is at/below threshold regardless of
+    /// `notify`, so a silent import acknowledges the low state (the in-app Low
+    /// badge still shows) without re-notifying on the next foreground recompute.
+    private static func evaluateLowStock(_ item: InventoryItem, notify: Bool) {
+        guard let threshold = item.lowStockThreshold, threshold > 0 else {
+            item.lowStockNotified = false
+            return
+        }
+        if item.currentQuantity > threshold {
+            item.lowStockNotified = false
+            return
+        }
+        guard !item.lowStockNotified else { return }
+        item.lowStockNotified = true
+        if notify {
+            DoseNotificationManager.inventoryLowStock(
+                substance: item.substance,
+                remaining: item.currentQuantity,
+                unit: item.unit,
+                isOut: item.currentQuantity <= 0,
+                itemID: item.id,
+            )
+        }
+    }
+
+    /// `nil` for non-positive inputs; the value otherwise. Centralizes the
+    /// "0 = off" convention shared by baseline, threshold, and dose size.
+    private static func normalizedPositive(_ value: Double?) -> Double? {
+        guard let value, value > 0 else { return nil }
+        return value
+    }
+
+    /// Persist the substance's stable deterministic color if it has none yet, so
+    /// a first-time-tracked substance appears in the colors menu and is editable
+    /// right away — without waiting for its first logged dose. Mirrors the
+    /// `ensureColor` the logging paths run, and uses the same
+    /// `PresetColor.deterministic` that `SubstancePalette` falls back to, so the
+    /// persisted color matches what inventory already showed.
+    private static func ensureColor(for substance: String, in ctx: ModelContext) {
+        let name = substance.trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else { return }
+        let existing = (try? ctx.fetch(FetchDescriptor<SubstanceColor>())) ?? []
+        guard !existing.hasColor(for: name) else { return }
+        ctx.insert(SubstanceColor(substance: name, hexColor: PresetColor.deterministic(for: name).hex))
+    }
+}

--- a/Piru/Data/StoreRecovery.swift
+++ b/Piru/Data/StoreRecovery.swift
@@ -69,6 +69,7 @@ nonisolated enum StoreRecovery {
             QuickLogDose.self,
             Session.self,
             DoseRoutine.self,
+            InventoryItem.self,
         ]
     }
 

--- a/Piru/Localizable.xcstrings
+++ b/Piru/Localizable.xcstrings
@@ -515,6 +515,16 @@
         }
       }
     },
+    "%@ %@ of %@ left." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@ of %3$@ left."
+          }
+        }
+      }
+    },
     "%@ %@ remaining after %@" : {
       "localizations" : {
         "en" : {
@@ -728,6 +738,9 @@
         }
       }
     },
+    "%@ left" : {
+
+    },
     "%@–%@ days" : {
       "comment" : "Long-acting release window",
       "localizations" : {
@@ -801,6 +814,29 @@
           }
         }
       }
+    },
+    "%@, %@ %@ in stock" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$@ %3$@ in stock"
+          }
+        }
+      }
+    },
+    "%@, %@ %@ in stock, low" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$@ %3$@ in stock, low"
+          }
+        }
+      }
+    },
+    "%@, out of stock" : {
+
     },
     "%@, source: %@" : {
       "localizations" : {
@@ -1806,6 +1842,22 @@
         }
       }
     },
+    "~%lld days" : {
+
+    },
+    "~%lld doses · %@ left" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "~%1$lld doses · %2$@ left"
+          }
+        }
+      }
+    },
+    "~%lld doses left" : {
+
+    },
     "~%lld minutes" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1821,6 +1873,12 @@
           }
         }
       }
+    },
+    "~%lld months" : {
+
+    },
+    "~%lld weeks" : {
+
     },
     "~%lld-%lld minutes" : {
       "extractionState" : "stale",
@@ -3317,6 +3375,9 @@
         }
       }
     },
+    "Add Inventory Item" : {
+
+    },
     "Add Item" : {
       "localizations" : {
         "zh-Hans" : {
@@ -3756,6 +3817,9 @@
         }
       }
     },
+    "Adjustment" : {
+
+    },
     "Afterglow" : {
       "localizations" : {
         "zh-Hans" : {
@@ -4093,6 +4157,9 @@
           }
         }
       }
+    },
+    "Amount added" : {
+
     },
     "AMP-Activated Protein Kinase (AMPK) Activator" : {
       "extractionState" : "stale",
@@ -5048,6 +5115,9 @@
           }
         }
       }
+    },
+    "Baseline (100%)" : {
+
     },
     "Be easy with yourself — profound experiences need time to settle." : {
       "localizations" : {
@@ -7780,6 +7850,9 @@
         }
       }
     },
+    "Custom substance — its doses count by exact name match." : {
+
+    },
     "Custom substance (no dose data)" : {
       "localizations" : {
         "zh-Hans" : {
@@ -7926,6 +7999,9 @@
           }
         }
       }
+    },
+    "Daily avg %@" : {
+
     },
     "Daily Medications" : {
       "localizations" : {
@@ -9382,6 +9458,9 @@
         }
       }
     },
+    "Doses in other units aren't counted." : {
+
+    },
     "Doses logged before this hour are grouped with the previous day's session — so a 02:00 dose joins the night before instead of starting a new day at midnight. Set to 12 AM for classic calendar-day grouping." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -10771,6 +10850,9 @@
           }
         }
       }
+    },
+    "Estimated from your average daily use over the last 7 days. Shown only when you've dosed on most days, so a one-off doesn't skew it." : {
+
     },
     "Estimates based on pharmacokinetic modeling. Actual levels may vary." : {
       "localizations" : {
@@ -12729,6 +12811,9 @@
         }
       }
     },
+    "History" : {
+
+    },
     "HMG-CoA Reductase Inhibitor (Statin)" : {
       "localizations" : {
         "zh-Hans" : {
@@ -12824,6 +12909,9 @@
           }
         }
       }
+    },
+    "How this is calculated" : {
+
     },
     "How you feel depends on what you took, how much, and your body's chemistry." : {
       "localizations" : {
@@ -13650,6 +13738,9 @@
         }
       }
     },
+    "Initial" : {
+
+    },
     "Initially classified as a serotonin reuptake enhancer, but now understood to primarily act as a full agonist at μ-opioid receptors (MOR) and δ-opioid receptors. MOR activation in the mesolimbic system produces antidepressant, anxiolytic, and analgesic effects. Also modulates glutamatergic neurotransmission and neuroplasticity in the hippocampus and amygdala." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -13843,6 +13934,9 @@
           }
         }
       }
+    },
+    "Inventory" : {
+
     },
     "Inverse Agonist" : {
       "localizations" : {
@@ -14327,6 +14421,9 @@
           }
         }
       }
+    },
+    "last dose %@" : {
+
     },
     "LD50 (dermal, rodent)" : {
       "localizations" : {
@@ -15145,6 +15242,9 @@
           }
         }
       }
+    },
+    "Marks the amount after this as a full supply, so the bar can show how full you are. Leave off if this isn't a full restock." : {
+
     },
     "max" : {
       "localizations" : {
@@ -16682,6 +16782,9 @@
         }
       }
     },
+    "No Inventory Yet" : {
+
+    },
     "No known interactions found." : {
       "localizations" : {
         "zh-Hans" : {
@@ -16777,6 +16880,9 @@
           }
         }
       }
+    },
+    "No restocks or doses yet." : {
+
     },
     "No Results" : {
       "localizations" : {
@@ -17171,6 +17277,9 @@
         }
       }
     },
+    "Not tracked" : {
+
+    },
     "Note" : {
       "localizations" : {
         "zh-Hans" : {
@@ -17426,6 +17535,9 @@
           }
         }
       }
+    },
+    "On hand" : {
+
     },
     "On This Device" : {
       "localizations" : {
@@ -17685,6 +17797,15 @@
           }
         }
       }
+    },
+    "Out" : {
+
+    },
+    "Out of %@" : {
+
+    },
+    "Out of stock" : {
+
     },
     "Over the next hours" : {
       "localizations" : {
@@ -18561,6 +18682,7 @@
       }
     },
     "Piru and PsychonautWiki files are plain, unencrypted JSON. Imported entries are added to your journal (duplicates are skipped). Encrypted restores can merge or replace." : {
+      "extractionState" : "stale",
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
@@ -18575,6 +18697,9 @@
           }
         }
       }
+    },
+    "Piru and PsychonautWiki files are plain, unencrypted JSON. Imported entries are added to your journal (duplicates are skipped). Encrypted restores can merge or replace. Inventory is included in Piru and encrypted backups, but not PsychonautWiki files." : {
+
     },
     "Piru Backup" : {
       "localizations" : {
@@ -20492,6 +20617,9 @@
         }
       }
     },
+    "Restock" : {
+
+    },
     "Restore" : {
       "localizations" : {
         "zh-Hans" : {
@@ -20973,6 +21101,12 @@
           }
         }
       }
+    },
+    "Run-out estimate" : {
+
+    },
+    "Running low on %@" : {
+
     },
     "S" : {
       "localizations" : {
@@ -22364,6 +22498,9 @@
         }
       }
     },
+    "Set as new baseline" : {
+
+    },
     "Set Time" : {
       "localizations" : {
         "zh-Hans" : {
@@ -22651,6 +22788,19 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "類似於阿立哌唑,作為多巴胺 D2 和血清素 5-HT1A 受體的部分激動劑,以及 5-HT2A 受體的拮抗劑。與阿立哌唑相比,在 D2 受體上的內在活性較低(更像拮抗劑),5-HT1A 部分激動更強,這可能減少靜坐不能並改善耐受性。"
+          }
+        }
+      }
+    },
+    "Single dose" : {
+
+    },
+    "Single dose %@ %@ · daily avg %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Single dose %1$@ %2$@ · daily avg %3$@"
           }
         }
       }
@@ -23398,6 +23548,9 @@
           }
         }
       }
+    },
+    "Starting amount" : {
+
     },
     "Starting from" : {
       "localizations" : {
@@ -24551,6 +24704,9 @@
         }
       }
     },
+    "The amount that counts as a full supply for the bar. Set to 0 to hide the bar." : {
+
+    },
     "The crash is your nervous system demanding rest and replenishment." : {
       "localizations" : {
         "zh-Hans" : {
@@ -24599,6 +24755,9 @@
           }
         }
       }
+    },
+    "The exact amount you have now. Changing it is logged as a correction." : {
+
     },
     "The foggy feeling will clear. Give it hours, not minutes." : {
       "localizations" : {
@@ -25412,6 +25571,15 @@
     "TPSA" : {
 
     },
+    "Track" : {
+
+    },
+    "Track a Substance" : {
+
+    },
+    "Track a substance to see how much you have left as you log doses." : {
+
+    },
     "Track active substances on your Lock Screen and Dynamic Island." : {
       "localizations" : {
         "zh-Hans" : {
@@ -25427,6 +25595,12 @@
           }
         }
       }
+    },
+    "Track how much you have on hand" : {
+
+    },
+    "Track Substance" : {
+
     },
     "Tracking started. Effects on the way." : {
       "localizations" : {
@@ -25937,6 +26111,9 @@
         }
       }
     },
+    "Use as baseline" : {
+
+    },
     "Use at least %lld characters. A phrase of several words is stronger and easier to remember than a short password." : {
       "localizations" : {
         "zh-Hans" : {
@@ -25985,6 +26162,9 @@
           }
         }
       }
+    },
+    "Used to show how many doses you have left. Set to 0 to disable." : {
+
     },
     "Vandrevala Foundation" : {
       "localizations" : {
@@ -26314,6 +26494,9 @@
           }
         }
       }
+    },
+    "Warn when below" : {
+
     },
     "Weak μ-Opioid Agonist and Serotonin-Norepinephrine Reuptake Inhibitor" : {
       "extractionState" : "stale",
@@ -26749,6 +26932,9 @@
         }
       }
     },
+    "You're out of %@. Restock when you can." : {
+
+    },
     "You're safe. If the experience was intense, remind yourself: it's temporary." : {
       "localizations" : {
         "zh-Hans" : {
@@ -27036,6 +27222,9 @@
           }
         }
       }
+    },
+    "Your remaining amount stands out once it drops below this. Set to 0 to disable." : {
+
     },
     "Your serotonin receptors are returning to their normal sensitivity." : {
       "localizations" : {

--- a/Piru/Navigation/AppDestinations.swift
+++ b/Piru/Navigation/AppDestinations.swift
@@ -123,6 +123,7 @@ private struct PushRouteView: View {
         case .volumetric: VolumetricDosingView()
         case .recovery: ComedownGuideView()
         case .pharma: AdvancedSearchView()
+        case .inventory: InventoryListView()
         }
     }
 

--- a/Piru/Navigation/DeepLink.swift
+++ b/Piru/Navigation/DeepLink.swift
@@ -207,7 +207,9 @@ nonisolated enum DeepLink {
              .timeAdjust,
              .dayShare,
              .sourcePriority,
-             .advancedSearch:
+             .advancedSearch,
+             .inventoryItemForm,
+             .inventoryItemEdit:
             // Not represented as deep links — these are app-internal flows.
             return nil
         }

--- a/Piru/Navigation/Routes.swift
+++ b/Piru/Navigation/Routes.swift
@@ -112,6 +112,15 @@ nonisolated enum SheetRoute: Hashable, Identifiable, Codable {
     /// return to the originating sheet.
     case colorPicker(substance: String, remaining: [String] = [], dismissAllOnComplete: Bool = false)
 
+    // Inventory
+    /// Add / restock sheet. `id == nil` is the generic add form (with a
+    /// Substance picker); a non-nil id restocks that existing item (and the
+    /// Substance field is omitted). `prefillSubstance`/`prefillSalt` open the add
+    /// form pre-targeted at a substance (the "Track" button in substance detail).
+    case inventoryItemForm(id: UUID?, prefillSubstance: String? = nil, prefillSalt: String? = nil)
+    /// Edit screen reached from the detail-view pencil.
+    case inventoryItemEdit(id: UUID)
+
     // Day utilities
     case journalFilters
     case journalCalendar

--- a/Piru/Navigation/SheetRouteView.swift
+++ b/Piru/Navigation/SheetRouteView.swift
@@ -97,6 +97,12 @@ struct SheetRouteView: View {
                     .withCancellationCloseButton()
             }
 
+        case let .inventoryItemForm(id, prefillSubstance, prefillSalt):
+            InventoryItemFormHost(itemID: id, prefillSubstance: prefillSubstance, prefillSalt: prefillSalt)
+
+        case let .inventoryItemEdit(id):
+            InventoryItemEditHost(itemID: id)
+
         case .dailyDoseItemForm,
              .customSubstancesList,
              .customSubstanceForm,

--- a/Piru/PiruApp.swift
+++ b/Piru/PiruApp.swift
@@ -84,6 +84,9 @@ struct PiruApp: App {
                     // and failure-isolated (only sets the optional relationship).
                     SessionService.ensureSessionsPopulated(in: container.mainContext)
                     ActiveSessionManager.shared.recoverSession(container: container)
+                    // Warm the inventory caches so badges/widget read fresh
+                    // numbers on first paint (cheap; only touches tracked items).
+                    InventoryService.recomputeAll(in: container.mainContext)
                     #if DEBUG
                         DemoData.insertShowcaseData(container: container)
                     #endif
@@ -91,6 +94,12 @@ struct PiruApp: App {
         }
         .modelContainer(container)
         .onChange(of: scenePhase) { _, phase in
+            // Coming back to the foreground: re-derive inventory caches so any
+            // doses logged from the widget / other surfaces while away are
+            // reflected, and a crossed threshold can notify.
+            if phase == .active {
+                InventoryService.recomputeAll(in: container.mainContext)
+            }
             // Opt-in, end-to-end encrypted iCloud backup on backgrounding. No-op
             // unless the user enabled it; debounced and change-gated internally.
             if phase == .background {

--- a/Piru/Utilities/DataExportImport.swift
+++ b/Piru/Utilities/DataExportImport.swift
@@ -498,6 +498,10 @@ private nonisolated struct PiruFile: Codable {
     var userColors: [PiruUserColorData]
     var favorites: [PiruFavoriteData]
     var customSubstances: [PsyLogCustomSubstance]
+    /// Optional for back-compat: files written before inventory tracking omit
+    /// the key, which decodes to `nil` (treated as empty). Mirrors the
+    /// `id`/`saltForm` optional-on-decode pattern the dose data uses.
+    var inventory: [PiruInventoryData]?
 }
 
 private nonisolated struct PiruSessionData: Codable {
@@ -559,6 +563,31 @@ private nonisolated struct PiruUserColorData: Codable {
 private nonisolated struct PiruFavoriteData: Codable {
     var substance: String
     var createdAt: Int64
+}
+
+/// Everything needed to reconstruct an inventory item's stock. `currentQuantity`
+/// and `lowStockNotified` are intentionally omitted — both are derived/transient
+/// and rebuilt by `recomputeAll` after import. `trackingStart` is preserved so
+/// the dose-consumption window matches the source device exactly.
+private nonisolated struct PiruInventoryData: Codable {
+    var substance: String
+    var saltForm: String?
+    var unit: String
+    var trackingStart: Int64
+    var lowStockThreshold: Double?
+    var baselineQuantity: Double?
+    var doseSize: Double?
+    var createdAt: Int64
+    var manualEvents: [PiruManualEventData]
+}
+
+private nonisolated struct PiruManualEventData: Codable {
+    var id: UUID
+    var kind: String
+    var amount: Double
+    var date: Int64
+    var note: String?
+    var setsBaseline: Bool
 }
 
 // MARK: - Export / Import
@@ -699,6 +728,7 @@ enum DataExportImport {
         let colors = try context.fetch(FetchDescriptor<SubstanceColor>())
         let userColors = try context.fetch(FetchDescriptor<UserColor>())
         let favorites = try context.fetch(FetchDescriptor<FavoriteSubstance>())
+        let inventoryItems = try context.fetch(FetchDescriptor<InventoryItem>())
 
         func doseData(_ e: DoseEntry) -> PiruDoseData {
             PiruDoseData(
@@ -743,6 +773,28 @@ enum DataExportImport {
             userColors: userColors.map { PiruUserColorData(hex: $0.hex, name: $0.name, createdAt: $0.createdAt.msSince1970) },
             favorites: favorites.map { PiruFavoriteData(substance: $0.substance, createdAt: $0.createdAt.msSince1970) },
             customSubstances: customStore.all.map(PsyLogCustomSubstance.init),
+            inventory: inventoryItems.map { item in
+                PiruInventoryData(
+                    substance: item.substance,
+                    saltForm: item.saltForm,
+                    unit: item.unit,
+                    trackingStart: item.trackingStart.msSince1970,
+                    lowStockThreshold: item.lowStockThreshold,
+                    baselineQuantity: item.baselineQuantity,
+                    doseSize: item.doseSize,
+                    createdAt: item.createdAt.msSince1970,
+                    manualEvents: item.manualEvents.map { event in
+                        PiruManualEventData(
+                            id: event.id,
+                            kind: event.kind.rawValue,
+                            amount: event.amount,
+                            date: event.date.msSince1970,
+                            note: event.note,
+                            setsBaseline: event.setsBaseline,
+                        )
+                    },
+                )
+            },
         )
     }
 
@@ -991,6 +1043,52 @@ enum DataExportImport {
                 isBackgroundMed: item.isBackgroundMed,
             ))
         }
+
+        // Inventory — merge by (substance, salt): union manual events by id so a
+        // re-import is idempotent, keep the earliest trackingStart, and fill any
+        // missing scalar settings. Then recompute caches now that doses and
+        // inventory are both in — silently, so a restore doesn't fire a low-stock
+        // alert per item.
+        if let importedInventory = file.inventory, !importedInventory.isEmpty {
+            let existingItems = (try? context.fetch(FetchDescriptor<InventoryItem>())) ?? []
+            for inv in importedInventory {
+                let importedEvents = inv.manualEvents.map { event in
+                    ManualEvent(
+                        id: event.id,
+                        kind: ManualEvent.Kind(rawValue: event.kind) ?? .restock,
+                        amount: event.amount,
+                        date: Date(ms: event.date),
+                        note: event.note,
+                        setsBaseline: event.setsBaseline,
+                    )
+                }
+                if let item = existingItems.first(where: {
+                    $0.substance.lowercased() == inv.substance.lowercased() && $0.saltForm == inv.saltForm
+                }) {
+                    var byID = Dictionary(item.manualEvents.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+                    for event in importedEvents where byID[event.id] == nil { byID[event.id] = event }
+                    item.manualEvents = byID.values.sorted { $0.date < $1.date }
+                    let importedStart = Date(ms: inv.trackingStart)
+                    if importedStart < item.trackingStart { item.trackingStart = importedStart }
+                    if item.lowStockThreshold == nil { item.lowStockThreshold = inv.lowStockThreshold }
+                    if item.baselineQuantity == nil { item.baselineQuantity = inv.baselineQuantity }
+                    if item.doseSize == nil { item.doseSize = inv.doseSize }
+                } else {
+                    context.insert(InventoryItem(
+                        substance: inv.substance,
+                        saltForm: inv.saltForm,
+                        unit: inv.unit,
+                        trackingStart: Date(ms: inv.trackingStart),
+                        lowStockThreshold: inv.lowStockThreshold,
+                        baselineQuantity: inv.baselineQuantity,
+                        doseSize: inv.doseSize,
+                        manualEvents: importedEvents,
+                        createdAt: Date(ms: inv.createdAt),
+                    ))
+                }
+            }
+        }
+        InventoryService.recomputeAll(in: context, notify: false)
     }
 
     /// Merge imported custom substances into the store: add new ones, update
@@ -1086,6 +1184,7 @@ enum DataExportImport {
         try context.delete(model: SubstanceColor.self)
         try context.delete(model: UserColor.self)
         try context.delete(model: FavoriteSubstance.self)
+        try context.delete(model: InventoryItem.self)
     }
 
     static var exportFilename: String {

--- a/Piru/Utilities/DoseNotificationManager.swift
+++ b/Piru/Utilities/DoseNotificationManager.swift
@@ -144,6 +144,48 @@ enum DoseNotificationManager {
         routineReminderPrefix + name.lowercased()
     }
 
+    // MARK: - Inventory low-stock
+
+    /// Deliver a one-shot low-stock (or out-of-stock) alert for an inventory
+    /// item. De-duping is owned by `InventoryService` via the item's
+    /// `lowStockNotified` flag, so this just builds and posts the request.
+    ///
+    /// Delivered immediately (`trigger: nil`); iOS suppresses banners while the
+    /// app is foregrounded — the alert then surfaces on the Lock/Home screen the
+    /// next time the user leaves the app, which is the intended "you've run low"
+    /// nudge for a threshold crossed by an in-app log.
+    static func inventoryLowStock(
+        substance: String,
+        remaining: Double,
+        unit: String,
+        isOut: Bool,
+        itemID: UUID,
+    ) {
+        Task {
+            guard await RampDownScheduler.requestPermissionIfNeeded() else { return }
+            let content = UNMutableNotificationContent()
+            if isOut {
+                content.title = String(localized: "Out of \(substance)")
+                content.body = String(localized: "You're out of \(substance). Restock when you can.")
+            } else {
+                content.title = String(localized: "Running low on \(substance)")
+                content.body = String(localized: "\(remaining.doseFormatted) \(unit) of \(substance) left.")
+            }
+            content.sound = .default
+            try? await UNUserNotificationCenter.current().add(UNNotificationRequest(
+                identifier: inventoryNotificationIdentifier(itemID),
+                content: content,
+                trigger: nil,
+            ))
+        }
+    }
+
+    private static let inventoryLowStockPrefix = "inventoryLowStock_"
+
+    private static func inventoryNotificationIdentifier(_ id: UUID) -> String {
+        inventoryLowStockPrefix + id.uuidString
+    }
+
     // MARK: - Deep links
 
     nonisolated static let deepLinkUserInfoKey = "deepLink"

--- a/Piru/Views/DataStorageView.swift
+++ b/Piru/Views/DataStorageView.swift
@@ -23,6 +23,7 @@ struct DataStorageView: View {
     @Query private var substanceColors: [SubstanceColor]
     @Query private var userColors: [UserColor]
     @Query private var quickLogDoses: [QuickLogDose]
+    @Query private var inventoryItems: [InventoryItem]
 
     // Encrypted export flow.
     @State private var showingExportPassphrase = false
@@ -147,6 +148,7 @@ struct DataStorageView: View {
             countRow("Daily Medications", systemImage: "cross.case", count: dailyItems.count)
             countRow("Quick-Log Shortcuts", systemImage: "bolt", count: quickLogDoses.count)
             countRow("Favorites", systemImage: "star", count: favorites.count)
+            countRow("Inventory", systemImage: "shippingbox", count: inventoryItems.count)
             countRow("Custom Colors", systemImage: "paintpalette", count: substanceColors.count + userColors.count)
             LabeledContent {
                 Text(byteString(StoreRecovery.canonicalStoreBytes())).foregroundStyle(Theme.secondaryLabel)
@@ -233,7 +235,7 @@ struct DataStorageView: View {
         } header: {
             Text("Export & Import")
         } footer: {
-            Text("Piru and PsychonautWiki files are plain, unencrypted JSON. Imported entries are added to your journal (duplicates are skipped). Encrypted restores can merge or replace.")
+            Text("Piru and PsychonautWiki files are plain, unencrypted JSON. Imported entries are added to your journal (duplicates are skipped). Encrypted restores can merge or replace. Inventory is included in Piru and encrypted backups, but not PsychonautWiki files.")
         }
         .disabled(generatingFormat != nil)
     }

--- a/Piru/Views/EntryDetailView.swift
+++ b/Piru/Views/EntryDetailView.swift
@@ -634,6 +634,7 @@ struct EntryDetailView: View {
         // must drop them and reschedule from its new time.
         DoseNotificationManager.doseRescheduled(entry: entry, previousTimestamp: previousTimestamp)
 
+        InventoryService.recomputeAll(in: modelContext)
         WidgetCenter.shared.reloadAllTimelines()
         isEditing = false
     }
@@ -666,6 +667,7 @@ struct EntryDetailView: View {
             timestamp: timestamp,
             allColors: Array(substanceColors),
         )
+        InventoryService.recomputeAll(in: modelContext)
         WidgetCenter.shared.reloadAllTimelines()
         dismiss()
     }

--- a/Piru/Views/EntryFormView.swift
+++ b/Piru/Views/EntryFormView.swift
@@ -418,6 +418,7 @@ struct EntryFormView: View {
             DoseNotificationManager.doseLogged(entry: newEntry, recentEntries: Array(recentEntries))
         }
 
+        InventoryService.recomputeAll(in: modelContext)
         WidgetCenter.shared.reloadAllTimelines()
 
         // Auto-assign a stable palette colour for a brand-new substance up front

--- a/Piru/Views/Inventory/InventoryItemDetailView.swift
+++ b/Piru/Views/Inventory/InventoryItemDetailView.swift
@@ -1,0 +1,280 @@
+import SwiftData
+import SwiftUI
+import WidgetKit
+
+/// Detail for one inventory item: the current amount, the run-out estimate and
+/// its basis, the supply bar (baseline only), a primary Restock action, a nav
+/// Edit pencil, and the merged history of manual events and matching doses.
+///
+/// Built as a `List` so dose rows get native swipe-to-delete; the header lives in
+/// its own section styled to read as a card.
+struct InventoryItemDetailView: View {
+    @Bindable var item: InventoryItem
+
+    @Environment(\.appNavigator) private var navigator
+    @Environment(\.modelContext) private var modelContext
+    @Query private var substanceColors: [SubstanceColor]
+
+    @State private var showBasisInfo = false
+
+    private var colorMap: [String: Color] { Array(substanceColors).colorMap }
+    private var runOut: InventoryMath.RunOut? { InventoryMath.runOut(for: item, in: modelContext) }
+
+    var body: some View {
+        List {
+            headerSection
+            historySection
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(Theme.background)
+        .navigationTitle(item.displayTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    navigator.present(.inventoryItemEdit(id: item.id))
+                } label: {
+                    Image(systemName: "pencil")
+                }
+                .accessibilityLabel("Edit")
+            }
+        }
+        // Re-derive when returning from a restock/edit sheet or a dose change.
+        .onAppear { InventoryService.recompute(item, in: modelContext) }
+        .alert("Run-out estimate", isPresented: $showBasisInfo) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Estimated from your average daily use over the last 7 days. Shown only when you've dosed on most days, so a one-off doesn't skew it.")
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 14) {
+                StockAmountText(item: item, style: .largeTitle)
+                    .accessibilityLabel(accessibilityAmount)
+
+                if let fraction = item.fillFraction {
+                    InventorySupplyBar(fraction: fraction, tint: item.stockStatus.barTint)
+                }
+
+                if let runOut {
+                    Text(runOutLine(runOut))
+                        .font(.subheadline)
+                        .foregroundStyle(Theme.secondaryLabel)
+                    HStack(spacing: 6) {
+                        Text(basisLine(runOut))
+                            .font(.caption)
+                            .foregroundStyle(Theme.secondaryLabel)
+                        Button {
+                            showBasisInfo = true
+                        } label: {
+                            Image(systemName: "info.circle").font(.caption)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("How this is calculated")
+                    }
+                }
+
+                Button {
+                    navigator.present(.inventoryItemForm(id: item.id))
+                } label: {
+                    Text("Restock")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 2)
+            }
+            .padding(.vertical, 6)
+            .listRowBackground(Theme.cardBackground)
+        }
+    }
+
+    // MARK: - History
+
+    private var historySection: some View {
+        Section {
+            let rows = historyRows
+            if rows.isEmpty {
+                Text("No restocks or doses yet.")
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.secondaryLabel)
+                    .listRowBackground(Theme.cardBackground)
+            } else {
+                ForEach(rows) { row in
+                    rowView(row)
+                        .listRowBackground(Theme.cardBackground)
+                }
+            }
+        } header: {
+            Text("History")
+        }
+    }
+
+    @ViewBuilder
+    private func rowView(_ row: HistoryRow) -> some View {
+        switch row {
+        case let .dose(dose):
+            NavigationLink {
+                EntryDetailView(entry: dose)
+            } label: {
+                HistoryRowLabel(
+                    glyph: "pills",
+                    title: String(localized: "Dose"),
+                    amount: "−\(dose.amount.doseFormatted) \(dose.unit)",
+                    date: dose.timestamp,
+                    note: nil,
+                )
+            }
+            .swipeActions(edge: .trailing) {
+                Button(role: .destructive) { deleteDose(dose) } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+
+        case let .manual(event):
+            HistoryRowLabel(
+                glyph: glyph(for: event.kind),
+                title: title(for: event.kind),
+                amount: amountLabel(event),
+                date: event.date,
+                note: event.note,
+            )
+            .swipeActions(edge: .trailing) {
+                Button(role: .destructive) { deleteEvent(event) } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+        }
+    }
+
+    private var historyRows: [HistoryRow] {
+        let doseRows = InventoryMath.doses(for: item, in: modelContext).map { HistoryRow.dose($0) }
+        let manualRows = item.manualEvents.map { HistoryRow.manual($0) }
+        return (doseRows + manualRows).sorted { $0.date > $1.date }
+    }
+
+    // MARK: - Mutations
+
+    private func deleteDose(_ dose: DoseEntry) {
+        DoseNotificationManager.doseDeleted(timestamp: dose.timestamp)
+        modelContext.delete(dose)
+        InventoryService.recompute(item, in: modelContext)
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    private func deleteEvent(_ event: ManualEvent) {
+        item.manualEvents.removeAll { $0.id == event.id }
+        InventoryService.recompute(item, in: modelContext)
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    // MARK: - Run-out copy
+
+    private func runOutLine(_ runOut: InventoryMath.RunOut) -> String {
+        inventoryRunOutLine(for: item, runOut: runOut)
+    }
+
+    private func basisLine(_ runOut: InventoryMath.RunOut) -> String {
+        let avg = "\(runOut.dailyAvg.doseFormatted) \(item.unit)"
+        if let size = item.doseSize, size > 0 {
+            return String(localized: "Single dose \(size.doseFormatted) \(item.unit) · daily avg \(avg)")
+        }
+        return String(localized: "Daily avg \(avg)")
+    }
+
+    private func glyph(for kind: ManualEvent.Kind) -> String {
+        switch kind {
+        case .initial: "plus.circle"
+        case .restock: "cart"
+        case .adjustment: "slider.horizontal.3"
+        }
+    }
+
+    private func title(for kind: ManualEvent.Kind) -> String {
+        switch kind {
+        case .initial: String(localized: "Initial")
+        case .restock: String(localized: "Restock")
+        case .adjustment: String(localized: "Adjustment")
+        }
+    }
+
+    private func amountLabel(_ event: ManualEvent) -> String {
+        let sign = event.amount >= 0 ? "+" : "−"
+        return "\(sign)\(abs(event.amount).doseFormatted) \(item.unit)"
+    }
+
+    private var accessibilityAmount: String {
+        switch item.stockStatus {
+        case .out:
+            return String(localized: "\(item.substance), out of stock")
+        case .low:
+            return String(localized: "\(item.substance), \(item.currentQuantity.doseFormatted) \(item.unit) in stock, low")
+        case .ok:
+            return String(localized: "\(item.substance), \(item.currentQuantity.doseFormatted) \(item.unit) in stock")
+        }
+    }
+}
+
+// MARK: - History model
+
+/// One merged history entry: a logged dose or a manual event.
+private enum HistoryRow: Identifiable {
+    case dose(DoseEntry)
+    case manual(ManualEvent)
+
+    var id: String {
+        switch self {
+        case let .dose(dose): "dose-\(dose.id.uuidString)"
+        case let .manual(event): "manual-\(event.id.uuidString)"
+        }
+    }
+
+    var date: Date {
+        switch self {
+        case let .dose(dose): dose.timestamp
+        case let .manual(event): event.date
+        }
+    }
+}
+
+/// The visual content of a history row (icon, title, optional note, timestamp,
+/// trailing signed amount).
+private struct HistoryRowLabel: View {
+    let glyph: String
+    let title: String
+    let amount: String
+    let date: Date
+    let note: String?
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: glyph)
+                .font(.subheadline)
+                .foregroundStyle(Theme.secondaryLabel)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                if let note, !note.isEmpty {
+                    Text(note)
+                        .font(.caption)
+                        .foregroundStyle(Theme.secondaryLabel)
+                        .lineLimit(1)
+                }
+                Text(date.formatted(.dateTime.month().day().hour().minute()))
+                    .font(.caption2)
+                    .foregroundStyle(Theme.secondaryLabel)
+            }
+            Spacer(minLength: 8)
+            Text(amount)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.primary)
+        }
+    }
+}

--- a/Piru/Views/Inventory/InventoryItemEditView.swift
+++ b/Piru/Views/Inventory/InventoryItemEditView.swift
@@ -1,0 +1,158 @@
+import SwiftData
+import SwiftUI
+import WidgetKit
+
+// MARK: - Host
+
+/// Resolves the item id and hosts the Edit screen as a navigator sheet.
+struct InventoryItemEditHost: View {
+    let itemID: UUID
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.appNavigator) private var navigator
+
+    var body: some View {
+        if let item = resolve() {
+            InventoryItemEditView(item: item)
+        } else {
+            // Item vanished (deleted elsewhere) — close rather than show a blank.
+            Color.clear.onAppear { navigator.dismiss() }
+        }
+    }
+
+    private func resolve() -> InventoryItem? {
+        let id = itemID
+        var descriptor = FetchDescriptor<InventoryItem>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return try? modelContext.fetch(descriptor).first
+    }
+}
+
+// MARK: - Edit screen
+
+/// Edit an item's exact amount, baseline, single-dose size, and low-stock
+/// threshold. On-hand and Baseline are independent fields (a recount vs. the
+/// "full" reference). `0` disables baseline, single dose, and the threshold.
+///
+/// Uses ✕ / ✓ nav icons with the ✓ as the commit — no bottom button.
+struct InventoryItemEditView: View {
+    @Bindable var item: InventoryItem
+
+    @Environment(\.appNavigator) private var navigator
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var unit: String
+    @State private var onHand: Double
+    @State private var baseline: Double
+    @State private var doseSize: Double
+    @State private var threshold: Double
+
+    private static let unitOptions = ["µg", "mg", "g", "mL", "caps", "tabs", "drops"]
+
+    /// Always include the item's current unit so a peptide/IU unit not in the
+    /// common list doesn't render a blank picker.
+    private var unitChoices: [String] {
+        var options = Self.unitOptions
+        let current = unit.trimmingCharacters(in: .whitespaces)
+        if !current.isEmpty, !options.contains(current) {
+            options.insert(current, at: 0)
+        }
+        return options
+    }
+
+    init(item: InventoryItem) {
+        self.item = item
+        _unit = State(initialValue: item.unit)
+        _onHand = State(initialValue: item.currentQuantity)
+        _baseline = State(initialValue: item.baselineQuantity ?? 0)
+        _doseSize = State(initialValue: item.doseSize ?? 0)
+        _threshold = State(initialValue: item.lowStockThreshold ?? 0)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Picker("Unit", selection: $unit) {
+                        ForEach(unitChoices, id: \.self) { Text($0).tag($0) }
+                    }
+                }
+
+                Section {
+                    amountField("On hand", value: $onHand)
+                } footer: {
+                    Text("The exact amount you have now. Changing it is logged as a correction.")
+                }
+
+                Section {
+                    amountField("Baseline (100%)", value: $baseline)
+                } footer: {
+                    Text("The amount that counts as a full supply for the bar. Set to 0 to hide the bar.")
+                }
+
+                Section {
+                    amountField("Single dose", value: $doseSize)
+                } footer: {
+                    Text("Used to show how many doses you have left. Set to 0 to disable.")
+                }
+
+                Section {
+                    amountField("Warn when below", value: $threshold)
+                } footer: {
+                    Text("Your remaining amount stands out once it drops below this. Set to 0 to disable.")
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.background)
+            .navigationTitle("Edit")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button { navigator.dismiss() } label: { Image(systemName: "xmark") }
+                        .accessibilityLabel("Cancel")
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button { commit() } label: { Image(systemName: "checkmark") }
+                        .accessibilityLabel("Save")
+                }
+            }
+        }
+    }
+
+    private func amountField(_ label: LocalizedStringKey, value: Binding<Double>) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            TextField("0", value: value, format: .number)
+                .keyboardType(.decimalPad)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: 120)
+            Text(unit).foregroundStyle(Theme.secondaryLabel)
+        }
+    }
+
+    // MARK: - Commit
+
+    private func commit() {
+        // Unit first: converts manual events + any stored derived fields so the
+        // replay stays consistent. The user's typed scalar values below are
+        // already expressed in the (new) unit shown on screen, so they overwrite.
+        if unit != item.unit {
+            InventoryService.changeUnit(item, to: unit, in: modelContext)
+        }
+
+        // Only log a correction when the on-hand figure actually moved.
+        let current = InventoryMath.quantity(for: item, in: modelContext)
+        if abs(onHand - current) > 0.0001 {
+            InventoryService.correctTo(item, exact: onHand, note: nil, in: modelContext)
+        }
+
+        InventoryService.setBaseline(item, value: baseline, in: modelContext)
+        InventoryService.setDoseSize(item, value: doseSize)
+        item.lowStockThreshold = threshold > 0 ? threshold : nil
+
+        InventoryService.recompute(item, in: modelContext)
+        WidgetCenter.shared.reloadAllTimelines()
+        navigator.dismiss()
+    }
+}

--- a/Piru/Views/Inventory/InventoryItemForm.swift
+++ b/Piru/Views/Inventory/InventoryItemForm.swift
@@ -1,0 +1,237 @@
+import SwiftData
+import SwiftUI
+import WidgetKit
+
+// MARK: - Host
+
+/// Resolves the optional item id and hosts the add/restock form as a navigator
+/// sheet (so `navigator.dismiss()` works).
+struct InventoryItemFormHost: View {
+    let itemID: UUID?
+    let prefillSubstance: String?
+    let prefillSalt: String?
+
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        InventoryItemForm(
+            existingItem: itemID.flatMap(resolve),
+            prefillSubstance: prefillSubstance,
+            prefillSalt: prefillSalt,
+        )
+    }
+
+    private func resolve(_ id: UUID) -> InventoryItem? {
+        var descriptor = FetchDescriptor<InventoryItem>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return try? modelContext.fetch(descriptor).first
+    }
+}
+
+// MARK: - Form
+
+/// Add a new tracked item or restock an existing one. With an `existingItem` it's
+/// a restock (Substance omitted, unit fixed); otherwise it's the add form. When
+/// opened from a substance screen the substance is prefilled and fixed.
+///
+/// Uses ✕ / ✓ nav icons with the ✓ as the commit — no bottom button.
+struct InventoryItemForm: View {
+    let existingItem: InventoryItem?
+    let prefillSubstance: String?
+    let prefillSalt: String?
+
+    @Environment(\.appNavigator) private var navigator
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var substanceName: String
+    @State private var unit: String
+    @State private var amount: Double = 0
+    @State private var useBaseline = false
+    @State private var note = ""
+    @State private var showNote = false
+    /// The library match for the typed name, when one was picked. `nil` for a
+    /// custom (off-library) substance — still trackable, just no unit default.
+    @State private var selectedSubstance: Substance?
+
+    private static let unitOptions = ["µg", "mg", "g", "mL", "caps", "tabs", "drops"]
+
+    init(existingItem: InventoryItem?, prefillSubstance: String?, prefillSalt: String?) {
+        self.existingItem = existingItem
+        self.prefillSubstance = prefillSubstance
+        self.prefillSalt = prefillSalt
+        _substanceName = State(initialValue: existingItem?.substance ?? prefillSubstance ?? "")
+        _unit = State(initialValue: existingItem?.unit ?? "mg")
+    }
+
+    private var isRestock: Bool { existingItem != nil }
+    private var substanceFixed: Bool { existingItem != nil || prefillSubstance != nil }
+
+    /// The picker's choices, always including the currently-selected unit so a
+    /// substance whose unit isn't in the common list (peptides dosed in `IU`,
+    /// `mcg`, etc.) never renders a blank picker.
+    private var unitChoices: [String] {
+        var options = Self.unitOptions
+        let current = unit.trimmingCharacters(in: .whitespaces)
+        if !current.isEmpty, !options.contains(current) {
+            options.insert(current, at: 0)
+        }
+        return options
+    }
+
+    /// "Set as new baseline" once an item already has one, else "Use as baseline".
+    private var baselineLabel: LocalizedStringKey {
+        (existingItem?.hasBaseline ?? false) ? "Set as new baseline" : "Use as baseline"
+    }
+
+    private var canCommit: Bool {
+        if isRestock { return amount > 0 }
+        return !substanceName.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                substanceSection
+                amountSection
+                baselineSection
+                noteSection
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.background)
+            .navigationTitle(isRestock ? "Restock" : "Track Substance")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button { navigator.dismiss() } label: { Image(systemName: "xmark") }
+                        .accessibilityLabel("Cancel")
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button { commit() } label: { Image(systemName: "checkmark") }
+                        .accessibilityLabel("Save")
+                        .disabled(!canCommit)
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var substanceSection: some View {
+        if !substanceFixed {
+            Section {
+                SubstanceSearchField(text: $substanceName) { selected in
+                    selectSubstance(selected)
+                } onCustom: {
+                    selectedSubstance = nil
+                }
+                if selectedSubstance == nil, !substanceName.isEmpty {
+                    HStack(spacing: 4) {
+                        Image(systemName: "info.circle")
+                        Text("Custom substance — its doses count by exact name match.")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(Theme.secondaryLabel)
+                }
+            } header: {
+                Text("Substance")
+            }
+        } else {
+            Section {
+                LabeledContent("Substance") {
+                    Text(displaySubstance).foregroundStyle(Theme.secondaryLabel)
+                }
+            }
+        }
+    }
+
+    /// Adopt a picked library substance: lock in its canonical name and default
+    /// the unit from its primary route (peptides, etc. aren't oral), which the
+    /// user can still change.
+    private func selectSubstance(_ substance: Substance) {
+        selectedSubstance = substance
+        substanceName = substance.name
+        let resolved = substance.unit(for: substance.defaultRoute, saltForm: prefillSalt)
+        unit = resolved.isEmpty ? "mg" : resolved
+    }
+
+    private var amountSection: some View {
+        Section {
+            HStack {
+                Text(isRestock ? "Amount added" : "Starting amount")
+                Spacer()
+                TextField("0", value: $amount, format: .number)
+                    .keyboardType(.decimalPad)
+                    .multilineTextAlignment(.trailing)
+                    .frame(maxWidth: 120)
+                if isRestock {
+                    Text(unit).foregroundStyle(Theme.secondaryLabel)
+                } else {
+                    Picker("", selection: $unit) {
+                        ForEach(unitChoices, id: \.self) { Text($0).tag($0) }
+                    }
+                    .labelsHidden()
+                }
+            }
+        }
+    }
+
+    private var baselineSection: some View {
+        Section {
+            Toggle(baselineLabel, isOn: $useBaseline)
+        } footer: {
+            Text("Marks the amount after this as a full supply, so the bar can show how full you are. Leave off if this isn't a full restock.")
+        }
+    }
+
+    @ViewBuilder
+    private var noteSection: some View {
+        Section {
+            if showNote {
+                TextField("Note", text: $note, axis: .vertical)
+                    .lineLimit(1...3)
+            } else {
+                Button {
+                    withAnimation { showNote = true }
+                } label: {
+                    Label("Add Note", systemImage: "text.alignleft")
+                }
+            }
+        }
+    }
+
+    private var displaySubstance: String {
+        let resolved = SubstanceLibrary.lookup(substanceName)?.displayTitle ?? substanceName
+        if let salt = prefillSalt ?? existingItem?.saltForm, !salt.isEmpty {
+            return "\(resolved) · \(salt)"
+        }
+        return resolved
+    }
+
+    // MARK: - Commit
+
+    private func commit() {
+        let trimmedNote = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let item = existingItem {
+            InventoryService.restock(
+                item,
+                amount: amount,
+                note: trimmedNote.isEmpty ? nil : trimmedNote,
+                setBaseline: useBaseline,
+                in: modelContext,
+            )
+        } else {
+            InventoryService.create(
+                substance: substanceName.trimmingCharacters(in: .whitespaces),
+                saltForm: prefillSalt,
+                unit: unit,
+                initial: amount,
+                threshold: nil,
+                setBaseline: useBaseline,
+                in: modelContext,
+            )
+        }
+        WidgetCenter.shared.reloadAllTimelines()
+        navigator.dismiss()
+    }
+}

--- a/Piru/Views/Inventory/InventoryListView.swift
+++ b/Piru/Views/Inventory/InventoryListView.swift
@@ -1,0 +1,237 @@
+import SwiftData
+import SwiftUI
+
+// MARK: - Sorting
+
+private extension InventoryItem {
+    /// Sort priority: out first, then low, then healthy.
+    var sortPriority: Int {
+        switch stockStatus {
+        case .out: 0
+        case .low: 1
+        case .ok: 2
+        }
+    }
+
+    /// Most recent manual activity, falling back to creation — used to order
+    /// items of equal status by "recently used".
+    var lastActivity: Date {
+        manualEvents.map(\.date).max() ?? createdAt
+    }
+}
+
+/// Order by status (out → low → ok), then most-recent activity within a status.
+private func inventorySorted(_ items: [InventoryItem]) -> [InventoryItem] {
+    items.sorted {
+        if $0.sortPriority != $1.sortPriority { return $0.sortPriority < $1.sortPriority }
+        return $0.lastActivity > $1.lastActivity
+    }
+}
+
+// MARK: - Tools summary card
+
+/// The Inventory entry on the Tools tab: a compact hub card showing the three
+/// highest-priority items (out → low → recent), tapping into the manager.
+struct InventorySummaryCard: View {
+    @Query private var items: [InventoryItem]
+    @Query private var substanceColors: [SubstanceColor]
+
+    private var colorMap: [String: Color] { Array(substanceColors).colorMap }
+    private var topItems: [InventoryItem] { Array(inventorySorted(items).prefix(3)) }
+
+    var body: some View {
+        NavigationLink(value: PushRoute.tool(.inventory)) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 14) {
+                    Image(systemName: Tool.inventory.icon)
+                        .font(.title2)
+                        .foregroundStyle(Theme.accent)
+                        .frame(width: 32)
+                    Text(Tool.inventory.name)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Spacer(minLength: 8)
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Theme.secondaryLabel)
+                }
+
+                if topItems.isEmpty {
+                    Text("Track how much you have on hand")
+                        .font(.subheadline)
+                        .foregroundStyle(Theme.secondaryLabel)
+                } else {
+                    VStack(spacing: 10) {
+                        ForEach(topItems) { item in
+                            InventorySummaryRow(item: item, colorMap: colorMap)
+                        }
+                    }
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .themeCard()
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// One image-style row inside the Tools summary card: dot + name, the plain
+/// number (colored only for Low/Out), and a bar below when a baseline exists.
+private struct InventorySummaryRow: View {
+    let item: InventoryItem
+    let colorMap: [String: Color]
+
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 8) {
+                SubstanceDot(name: item.substance, colorMap: colorMap)
+                Text(item.displayTitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                StockAmountText(item: item, style: .subheadline)
+            }
+            if let fraction = item.fillFraction {
+                InventorySupplyBar(fraction: fraction, tint: item.stockStatus.barTint)
+            }
+        }
+    }
+}
+
+// MARK: - Manager list
+
+/// The inventory manager: one grouped list (no section headers — low/out simply
+/// sort to the top), each row tapping into the item detail. The `+` opens the
+/// generic add form.
+struct InventoryListView: View {
+    @Query private var items: [InventoryItem]
+    @Query private var substanceColors: [SubstanceColor]
+    @Environment(\.appNavigator) private var navigator
+
+    private var colorMap: [String: Color] { Array(substanceColors).colorMap }
+    private var sorted: [InventoryItem] { inventorySorted(items) }
+
+    var body: some View {
+        Group {
+            if items.isEmpty {
+                ContentUnavailableView {
+                    Label("No Inventory Yet", systemImage: "shippingbox")
+                } description: {
+                    Text("Track a substance to see how much you have left as you log doses.")
+                } actions: {
+                    Button("Track a Substance") {
+                        navigator.present(.inventoryItemForm(id: nil))
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            } else {
+                List {
+                    ForEach(sorted) { item in
+                        NavigationLink {
+                            InventoryItemDetailView(item: item)
+                        } label: {
+                            InventoryRow(item: item, colorMap: colorMap)
+                        }
+                    }
+                }
+                .listStyle(.insetGrouped)
+                .scrollContentBackground(.hidden)
+            }
+        }
+        .background(Theme.background)
+        .navigationTitle("Inventory")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    navigator.present(.inventoryItemForm(id: nil))
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .accessibilityLabel("Add Inventory Item")
+            }
+        }
+    }
+}
+
+/// A manager row: dot, title (+ salt inline), a subtitle (doses-left, or
+/// last-dose date when out), the plain trailing number, and a status-tinted bar
+/// below when the item has a baseline.
+private struct InventoryRow: View {
+    let item: InventoryItem
+    let colorMap: [String: Color]
+
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                SubstanceDot(name: item.substance, colorMap: colorMap)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.displayTitle)
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(Theme.secondaryLabel)
+                    }
+                }
+                Spacer(minLength: 8)
+                StockAmountText(item: item, style: .body)
+            }
+            if let fraction = item.fillFraction {
+                InventorySupplyBar(fraction: fraction, tint: item.stockStatus.barTint)
+            }
+        }
+        .padding(.vertical, 2)
+        .listRowBackground(Theme.cardBackground)
+    }
+
+    /// "~N doses left" when a dose size is tracked; for an Out item the last-dose
+    /// date instead (so we don't repeat "Out"); otherwise nothing.
+    private var subtitle: String? {
+        if item.stockStatus == .out {
+            guard let last = InventoryMath.doses(for: item, in: modelContext).map(\.timestamp).max() else {
+                return nil
+            }
+            let formatted = last.formatted(.dateTime.month().day())
+            return String(localized: "last dose \(formatted)")
+        }
+        if let doses = InventoryMath.dosesLeft(for: item) {
+            return String(localized: "~\(doses) doses left")
+        }
+        return nil
+    }
+}
+
+// MARK: - Amount text
+
+/// The trailing stock number with a dimmed unit, or a colored "Out" — colored
+/// only for Low/Out per the governing rule.
+struct StockAmountText: View {
+    let item: InventoryItem
+    var style: Font = .body
+
+    var body: some View {
+        let status = item.stockStatus
+        if status == .out {
+            Text("Out")
+                .font(style.weight(.semibold))
+                .foregroundStyle(status.numberColor)
+        } else {
+            HStack(spacing: 3) {
+                Text(item.currentQuantity.doseFormatted)
+                    .font(style.weight(.semibold))
+                    .foregroundStyle(status.numberColor)
+                Text(item.unit)
+                    .font(.caption)
+                    .foregroundStyle(Theme.secondaryLabel)
+            }
+        }
+    }
+}

--- a/Piru/Views/Inventory/InventorySupport.swift
+++ b/Piru/Views/Inventory/InventorySupport.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+// MARK: - Stock status
+
+/// The health of an item's stock. Drives color, which — per the HIG rule the
+/// spec adopts — carries meaning *only* for Low/Out; a healthy supply reads
+/// neutral.
+enum StockStatus {
+    case ok
+    case low
+    case out
+
+    /// Number / label color. Neutral (`primary`) when healthy so color is
+    /// reserved for the states that need attention.
+    var numberColor: Color {
+        switch self {
+        case .ok: .primary
+        case .low: .orange
+        case .out: .red
+        }
+    }
+
+    /// Supply-bar fill color. Healthy is a neutral fill, not green.
+    var barTint: Color {
+        switch self {
+        case .ok: Color.primary.opacity(0.35)
+        case .low: .orange
+        case .out: .red
+        }
+    }
+}
+
+extension InventoryItem {
+    /// Healthy / low / out, derived from the cached quantity and threshold.
+    var stockStatus: StockStatus {
+        if currentQuantity <= 0 { return .out }
+        if let threshold = lowStockThreshold, threshold > 0, currentQuantity <= threshold { return .low }
+        return .ok
+    }
+
+    /// A baseline is "set" only when it's a positive number; `nil` or `0` mean
+    /// the supply bar is disabled.
+    var hasBaseline: Bool {
+        (baselineQuantity ?? 0) > 0
+    }
+
+    /// Fraction of the baseline currently on hand, clamped to `0...1`. `nil` when
+    /// no baseline is set (no bar).
+    var fillFraction: Double? {
+        guard let baseline = baselineQuantity, baseline > 0 else { return nil }
+        return min(1, max(0, currentQuantity / baseline))
+    }
+
+    /// Substance with its salt inline, so variants don't read as duplicates.
+    ///
+    /// The stored ``substance`` is the canonical name (so doses match); for
+    /// display we resolve it to the library's presentation name — the same one
+    /// the journal and quick-log show (e.g. canonical "Bromoketamine" →
+    /// "2-Br-DCK") — falling back to the stored name for custom substances.
+    @MainActor
+    var displayTitle: String {
+        let resolved = SubstanceLibrary.lookup(substance)?.displayTitle ?? substance
+        if let salt = saltForm, !salt.isEmpty {
+            return "\(resolved) · \(salt)"
+        }
+        return resolved
+    }
+}
+
+// MARK: - Run-out formatting (shared by detail + substance card)
+
+/// One-line run-out copy: "~N doses · ~N weeks left" (dropping the doses part
+/// when no dose size is set).
+@MainActor
+func inventoryRunOutLine(for item: InventoryItem, runOut: InventoryMath.RunOut) -> String {
+    let humanized = inventoryHumanizeDays(runOut.daysLeft)
+    if let doses = InventoryMath.dosesLeft(for: item) {
+        return String(localized: "~\(doses) doses · \(humanized) left")
+    }
+    return String(localized: "\(humanized) left")
+}
+
+/// Humanize a days-left figure: `< 14` → days, `< 60` → weeks, else months.
+func inventoryHumanizeDays(_ days: Double) -> String {
+    if days < 14 {
+        return String(localized: "~\(Int(days.rounded())) days")
+    } else if days < 60 {
+        return String(localized: "~\(Int((days / 7).rounded())) weeks")
+    }
+    return String(localized: "~\(Int((days / 30).rounded())) months")
+}
+
+// MARK: - Supply bar
+
+/// A thin status-tinted supply bar. Shown only when an item has a baseline.
+struct InventorySupplyBar: View {
+    let fraction: Double
+    let tint: Color
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.primary.opacity(0.08))
+                Capsule()
+                    .fill(tint)
+                    .frame(width: max(3, geo.size.width * fraction))
+            }
+        }
+        .frame(height: 6)
+        .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Substance dot
+
+/// The small colored dot identifying a substance, matching the journal's dots.
+struct SubstanceDot: View {
+    let name: String
+    let colorMap: [String: Color]
+    var size: CGFloat = 10
+
+    var body: some View {
+        Circle()
+            .fill(SubstancePalette.color(for: name, colorMap: colorMap))
+            .frame(width: size, height: size)
+    }
+}

--- a/Piru/Views/QuickLogView.swift
+++ b/Piru/Views/QuickLogView.swift
@@ -969,6 +969,7 @@ struct QuickLogView: View {
                 for entry in createdEntries {
                     DoseNotificationManager.doseLogged(entry: entry, recentEntries: recentEntries)
                 }
+                InventoryService.recomputeAll(in: context)
                 WidgetCenter.shared.reloadAllTimelines()
             }
         }

--- a/Piru/Views/SubstanceCardView.swift
+++ b/Piru/Views/SubstanceCardView.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 // MARK: - Substance Card
@@ -19,6 +20,9 @@ struct SubstanceCardView: View {
     let onRemoveChip: (SubstanceGroup, DoseChip) -> Void
 
     @State private var customSubstanceStore = CustomSubstanceStore.shared
+    /// Tracked inventory items — drives the passive "X left" hint. A `@Query`
+    /// here re-renders only this card when stock changes, never the whole list.
+    @Query private var inventoryItems: [InventoryItem]
     /// Substances whose PK badge has been expanded into the full advice card.
     @State private var expandedPK = false
     /// (substance|route) groups showing their full chip set instead of the
@@ -89,12 +93,44 @@ struct SubstanceCardView: View {
                 .accessibilityLabel("Collapse")
             }
 
+            inventoryHint
+
             ForEach(card.routes) { group in
                 routeSection(group)
             }
         }
         .padding(14)
         .background(RoundedRectangle(cornerRadius: 20).fill(Theme.cardBackground))
+    }
+
+    /// The matching tracked item for this card's substance (salt-agnostic — the
+    /// card isn't salt-specific; prefer the base form).
+    private var inventoryItem: InventoryItem? {
+        let name = card.substanceName.lowercased()
+        let matches = inventoryItems.filter { $0.substance.lowercased() == name }
+        return matches.first { $0.saltForm == nil } ?? matches.first
+    }
+
+    /// Passive stock hint (1B): a supply bar (only when a baseline is set) with
+    /// the "X left" amount on the line below. Nothing for untracked substances —
+    /// the quick-log flow stays nudge-free.
+    @ViewBuilder
+    private var inventoryHint: some View {
+        if let item = inventoryItem {
+            VStack(alignment: .leading, spacing: 4) {
+                if let fraction = item.fillFraction {
+                    InventorySupplyBar(fraction: fraction, tint: item.stockStatus.barTint)
+                }
+                Text(stockHintText(item))
+                    .font(.caption)
+                    .foregroundStyle(item.stockStatus == .ok ? Theme.secondaryLabel : item.stockStatus.numberColor)
+            }
+        }
+    }
+
+    private func stockHintText(_ item: InventoryItem) -> String {
+        if item.stockStatus == .out { return String(localized: "Out of stock") }
+        return String(localized: "\(item.currentQuantity.doseFormatted) \(item.unit) left")
     }
 
     private func routeSection(_ group: SubstanceGroup) -> some View {

--- a/Piru/Views/SubstanceLibraryView.swift
+++ b/Piru/Views/SubstanceLibraryView.swift
@@ -473,6 +473,7 @@ struct SubstanceDetailView: View {
     @Environment(\.appNavigator) private var navigator
     @Query private var historyEntries: [DoseEntry]
     @Query private var favorites: [FavoriteSubstance]
+    @Query private var inventoryItems: [InventoryItem]
     @State private var customStore = CustomSubstanceStore.shared
     @State private var showAllHistory = false
     @State private var showEntries = false
@@ -986,6 +987,95 @@ struct SubstanceDetailView: View {
         )
     }
 
+    // MARK: - Inventory stock card (2B)
+
+    /// The tracked item for this substance, preferring the currently-selected
+    /// salt, then the base form. Matched by canonical name (how stock is stored).
+    private var trackedItem: InventoryItem? {
+        let name = baseSubstance.name.lowercased()
+        let matches = inventoryItems.filter { $0.substance.lowercased() == name }
+        return matches.first { $0.saltForm == selectedSaltForm }
+            ?? matches.first { $0.saltForm == nil }
+            ?? matches.first
+    }
+
+    /// Rich stock card below Dose & Duration: amount, doses-left, supply bar, and
+    /// run-out when tracked; a quiet "Not tracked · Track" row otherwise.
+    @ViewBuilder
+    private var inventoryStockSection: some View {
+        Section {
+            if let item = trackedItem {
+                trackedStockCard(item)
+            } else {
+                HStack {
+                    Text("Not tracked")
+                        .foregroundStyle(Theme.secondaryLabel)
+                    Spacer()
+                    Button("Track") {
+                        navigator.present(.inventoryItemForm(
+                            id: nil,
+                            prefillSubstance: baseSubstance.name,
+                            prefillSalt: selectedSaltForm,
+                        ))
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(Theme.accent)
+                }
+            }
+        } header: {
+            Text("Inventory")
+        }
+    }
+
+    @ViewBuilder
+    private func trackedStockCard(_ item: InventoryItem) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            StockAmountText(item: item, style: .title2)
+            if let subtitle = stockSubtitle(item) {
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.secondaryLabel)
+            }
+            if let fraction = item.fillFraction {
+                InventorySupplyBar(fraction: fraction, tint: item.stockStatus.barTint)
+            }
+            if let runOut = InventoryMath.runOut(for: item, in: modelContext) {
+                Text(inventoryRunOutLine(for: item, runOut: runOut))
+                    .font(.caption)
+                    .foregroundStyle(Theme.secondaryLabel)
+            }
+            if hasUnitMismatch(item) {
+                Label("Doses in other units aren't counted.", systemImage: "info.circle")
+                    .font(.caption)
+                    .foregroundStyle(Theme.secondaryLabel)
+            }
+            Button("Restock") {
+                navigator.present(.inventoryItemForm(id: item.id))
+            }
+            .buttonStyle(.bordered)
+            .tint(Theme.accent)
+        }
+        .padding(.vertical, 4)
+    }
+
+    /// "Glycinate · ~3 doses left" — salt and/or doses-left, whichever apply.
+    private func stockSubtitle(_ item: InventoryItem) -> String? {
+        var parts: [String] = []
+        if let salt = item.saltForm, !salt.isEmpty { parts.append(salt) }
+        if let doses = InventoryMath.dosesLeft(for: item) {
+            parts.append(String(localized: "~\(doses) doses left"))
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// True when any matching dose can't be converted into the item's unit, so
+    /// the card can show a calm "not counted" hint.
+    private func hasUnitMismatch(_ item: InventoryItem) -> Bool {
+        InventoryMath.doses(for: item, in: modelContext).contains {
+            InventoryMath.convert($0.amount, from: $0.unit, to: item.unit) == nil
+        }
+    }
+
     /// Dose ladder + duration for the selected route, behind a segmented route
     /// switcher when more than one route applies. Surfaced near the top of the
     /// detail view — the primary thing people open a substance for. One
@@ -1398,6 +1488,8 @@ struct SubstanceDetailView: View {
                 }
 
                 doseDurationSections
+
+                inventoryStockSection
 
                 peptideSections
 

--- a/Piru/Views/SubstanceSearchField.swift
+++ b/Piru/Views/SubstanceSearchField.swift
@@ -26,6 +26,16 @@ struct SubstanceSearchField: View {
         return results.contains { $0.name.lowercased() == q || $0.aliases.contains { $0.lowercased() == q } }
     }
 
+    /// Canonical name + aliases for the subtitle, dropping whichever entries the
+    /// title (``Substance/displayTitle``) already shows, so the line doesn't echo
+    /// the title back (e.g. title "2-Br-DCK" → subtitle "Bromoketamine, …").
+    private func secondaryNames(for substance: Substance) -> String? {
+        let title = substance.displayTitle.lowercased()
+        let names = ([substance.name] + substance.aliases)
+            .filter { $0.lowercased() != title }
+        return names.isEmpty ? nil : names.prefix(3).joined(separator: ", ")
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             TextField("Substance name", text: $text)
@@ -81,7 +91,12 @@ struct SubstanceSearchField: View {
                                 HStack {
                                     VStack(alignment: .leading, spacing: 2) {
                                         HStack(spacing: 4) {
-                                            Text(substance.name)
+                                            // Show the same presentation name as
+                                            // the journal / quick-log (display
+                                            // override, regional name); the
+                                            // canonical name still leads the
+                                            // subtitle so it stays discoverable.
+                                            Text(substance.displayTitle)
                                                 .font(.body)
                                                 .foregroundStyle(.primary)
                                             if favoriteNames.contains(substance.name.lowercased()) {
@@ -90,8 +105,8 @@ struct SubstanceSearchField: View {
                                                     .foregroundStyle(.yellow)
                                             }
                                         }
-                                        if !substance.aliases.isEmpty {
-                                            Text(substance.aliases.prefix(3).joined(separator: ", "))
+                                        if let secondary = secondaryNames(for: substance) {
+                                            Text(secondary)
                                                 .font(.caption)
                                                 .foregroundStyle(Theme.secondaryLabel)
                                         }

--- a/Piru/Views/ToolsView.swift
+++ b/Piru/Views/ToolsView.swift
@@ -9,6 +9,7 @@ nonisolated enum Tool: String, Hashable, Codable, CaseIterable, Identifiable {
     case volumetric
     case recovery
     case pharma
+    case inventory
 
     var id: String {
         rawValue
@@ -22,6 +23,7 @@ nonisolated enum Tool: String, Hashable, Codable, CaseIterable, Identifiable {
         case .volumetric: "Volumetric Dosing"
         case .recovery: "Recovery Guide"
         case .pharma: "Pharma Search"
+        case .inventory: "Inventory"
         }
     }
 
@@ -33,6 +35,7 @@ nonisolated enum Tool: String, Hashable, Codable, CaseIterable, Identifiable {
         case .volumetric: "Dilute and measure precise doses"
         case .recovery: "Comedown and aftercare tips"
         case .pharma: "Search by receptor and affinity"
+        case .inventory: "Track how much you have on hand"
         }
     }
 
@@ -43,22 +46,30 @@ nonisolated enum Tool: String, Hashable, Codable, CaseIterable, Identifiable {
         case .volumetric: "drop"
         case .recovery: "heart.text.square"
         case .pharma: "pills"
+        case .inventory: "shippingbox"
         }
     }
 }
 
 /// The Tools tab root: a hub list of tools, each pushing a full-screen view.
+/// Inventory is rendered as a richer summary card (see ``InventorySummaryCard``)
+/// rather than a plain row, so the user can glance at what's low without opening
+/// the manager.
 struct ToolsView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 14) {
                 ForEach(Tool.allCases) { tool in
-                    NavigationLink(value: PushRoute.tool(tool)) {
-                        NavCardLabel(icon: tool.icon, title: Text(tool.name)) {
-                            Text(tool.subtitle)
+                    if tool == .inventory {
+                        InventorySummaryCard()
+                    } else {
+                        NavigationLink(value: PushRoute.tool(tool)) {
+                            NavCardLabel(icon: tool.icon, title: Text(tool.name)) {
+                                Text(tool.subtitle)
+                            }
                         }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
                 }
             }
             .padding(.horizontal)

--- a/PiruTests/InventoryExportTests.swift
+++ b/PiruTests/InventoryExportTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Piru
+
+@MainActor
+@Suite("Inventory — export/import")
+struct InventoryExportTests {
+    private func makeContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: Schema(StoreRecovery.models),
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true, cloudKitDatabase: .none),
+        )
+        return ModelContext(container)
+    }
+
+    private let drug = "ZZTestInventorySubstance"
+    private let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// Build a tracked item (initial 100 mg, baseline 100, threshold 10, dose
+    /// size 25) with one 30 mg dose, so live stock is 70.
+    private func seed(_ ctx: ModelContext) {
+        let item = InventoryItem(
+            substance: drug,
+            unit: "mg",
+            trackingStart: start,
+            lowStockThreshold: 10,
+            baselineQuantity: 100,
+            doseSize: 25,
+            manualEvents: [ManualEvent(kind: .initial, amount: 100, date: start, setsBaseline: true)],
+            createdAt: start,
+        )
+        ctx.insert(item)
+        ctx.insert(DoseEntry(substance: drug, amount: 30, unit: "mg", timestamp: start.addingTimeInterval(3_600)))
+        InventoryService.recompute(item, in: ctx)
+    }
+
+    @Test("Round-trip reproduces stock exactly")
+    func roundTrip() throws {
+        let ctx = try makeContext()
+        seed(ctx)
+        try ctx.save()
+        #expect(InventoryService.find(substance: drug, saltForm: nil, in: ctx)?.currentQuantity == 70)
+
+        let data = try DataExportImport.exportJSON(context: ctx)
+        try DataExportImport.deleteAll(context: ctx)
+        try ctx.save()
+        #expect(try ctx.fetch(FetchDescriptor<InventoryItem>()).isEmpty)
+
+        try DataExportImport.importJSON(data: data, context: ctx)
+        try ctx.save()
+
+        let items = try ctx.fetch(FetchDescriptor<InventoryItem>())
+        #expect(items.count == 1)
+        let item = try #require(items.first)
+        #expect(item.substance == drug)
+        #expect(item.unit == "mg")
+        #expect(item.baselineQuantity == 100)
+        #expect(item.lowStockThreshold == 10)
+        #expect(item.doseSize == 25)
+        #expect(abs(item.trackingStart.timeIntervalSince(start)) < 1)
+        #expect(item.manualEvents.count == 1)
+        #expect(item.manualEvents.first?.setsBaseline == true)
+        // The dose was re-imported too, so derived stock matches the source: 70.
+        #expect(item.currentQuantity == 70)
+    }
+
+    @Test("Re-importing the same file is idempotent")
+    func idempotentReimport() throws {
+        let ctx = try makeContext()
+        seed(ctx)
+        try ctx.save()
+        let data = try DataExportImport.exportJSON(context: ctx)
+
+        // Import on top of the existing data twice.
+        try DataExportImport.importJSON(data: data, context: ctx)
+        try DataExportImport.importJSON(data: data, context: ctx)
+        try ctx.save()
+
+        let items = try ctx.fetch(FetchDescriptor<InventoryItem>())
+        #expect(items.count == 1) // merged by (substance, salt), not duplicated
+        let item = try #require(items.first)
+        #expect(item.manualEvents.count == 1) // events unioned by id
+        #expect(item.currentQuantity == 70) // dose deduped by content
+    }
+
+    @Test("Import merges events into an existing item, keeping earliest start")
+    func mergeIntoExisting() throws {
+        // Source file: item created at `start` with the initial event.
+        let source = try makeContext()
+        seed(source)
+        try source.save()
+        let data = try DataExportImport.exportJSON(context: source)
+
+        // Destination already has the same substance, tracked LATER, with a
+        // different restock event.
+        let dest = try makeContext()
+        let laterStart = start.addingTimeInterval(10 * 86_400)
+        let destItem = InventoryItem(
+            substance: drug,
+            unit: "mg",
+            trackingStart: laterStart,
+            manualEvents: [ManualEvent(kind: .restock, amount: 50, date: laterStart)],
+            createdAt: laterStart,
+        )
+        dest.insert(destItem)
+        try dest.save()
+
+        try DataExportImport.importJSON(data: data, context: dest)
+        try dest.save()
+
+        let items = try dest.fetch(FetchDescriptor<InventoryItem>())
+        #expect(items.count == 1) // merged, not duplicated
+        let item = try #require(items.first)
+        #expect(item.manualEvents.count == 2) // restock (50) + imported initial (100)
+        #expect(abs(item.trackingStart.timeIntervalSince(start)) < 1) // earliest wins
+    }
+
+    @Test("PsyLog export omits inventory")
+    func psyLogOmitsInventory() throws {
+        let ctx = try makeContext()
+        seed(ctx)
+        try ctx.save()
+
+        let psyLog = try DataExportImport.exportJSON(format: .psyLog, context: ctx)
+        let json = try #require(try JSONSerialization.jsonObject(with: psyLog) as? [String: Any])
+        #expect(json["inventory"] == nil)
+
+        // Importing the PsyLog file into a clean store creates no inventory.
+        let fresh = try makeContext()
+        try DataExportImport.importJSON(data: psyLog, context: fresh)
+        try fresh.save()
+        #expect(try fresh.fetch(FetchDescriptor<InventoryItem>()).isEmpty)
+    }
+}

--- a/PiruTests/InventoryTests.swift
+++ b/PiruTests/InventoryTests.swift
@@ -1,0 +1,337 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Piru
+
+@MainActor
+@Suite("Inventory")
+struct InventoryTests {
+    /// An in-memory store with the full current schema.
+    private func makeContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: Schema(StoreRecovery.models),
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true, cloudKitDatabase: .none),
+        )
+        return ModelContext(container)
+    }
+
+    /// A name guaranteed absent from the substance library, so nothing depends on
+    /// bundled data.
+    private let drug = "ZZTestInventorySubstance"
+
+    /// Fixed clock so date math is deterministic.
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @discardableResult
+    private func logDose(
+        _ ctx: ModelContext,
+        substance: String? = nil,
+        amount: Double,
+        unit: String = "mg",
+        saltForm: String? = nil,
+        at offsetHours: Double = 1,
+    ) -> DoseEntry {
+        let entry = DoseEntry(
+            substance: substance ?? drug,
+            amount: amount,
+            unit: unit,
+            saltForm: saltForm,
+            timestamp: now.addingTimeInterval(offsetHours * 3_600),
+        )
+        ctx.insert(entry)
+        return entry
+    }
+
+    private func makeItem(
+        _ ctx: ModelContext,
+        substance: String? = nil,
+        unit: String = "mg",
+        trackingStart: Date? = nil,
+        saltForm: String? = nil,
+        initial: Double = 0,
+    ) -> InventoryItem {
+        let start = trackingStart ?? now
+        let item = InventoryItem(
+            substance: substance ?? drug,
+            saltForm: saltForm,
+            unit: unit,
+            trackingStart: start,
+            // The initial amount exists from the start of tracking, so date it at
+            // `trackingStart` — otherwise back-dated consumption would floor away
+            // before the stock "arrives".
+            manualEvents: initial == 0
+                ? []
+                : [ManualEvent(kind: .initial, amount: initial, date: start)],
+        )
+        ctx.insert(item)
+        return item
+    }
+
+    // MARK: - Replay, floor, forgive
+
+    @Test("Initial minus a converted dose")
+    func basicConsumption() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "g", initial: 5)
+        logDose(ctx, amount: 200, unit: "mg", at: 1) // 0.2 g
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 4.8)
+    }
+
+    @Test("Over-log floors at 0")
+    func overdrawFloors() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 30)
+        logDose(ctx, amount: 50, at: 1)
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 0)
+    }
+
+    @Test("Overdraw is forgiven before a later restock")
+    func overdrawThenRestock() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 30)
+        logDose(ctx, amount: 50, at: 1) // floors to 0
+        InventoryService.restock(item, amount: 100, note: nil, setBaseline: false, in: ctx)
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 100)
+    }
+
+    @Test("Negative adjustment floors at 0")
+    func negativeAdjustmentFloors() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 10)
+        InventoryService.correctTo(item, exact: 0, note: nil, in: ctx)
+        // A further down-adjustment can't go below 0.
+        item.manualEvents.append(ManualEvent(kind: .adjustment, amount: -5, date: now.addingTimeInterval(7_200)))
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 0)
+    }
+
+    // MARK: - Conversion / mismatch
+
+    @Test("Unit-mismatched dose is skipped, not blocked")
+    func unitMismatchSkipped() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 100)
+        logDose(ctx, amount: 5, unit: "mL", at: 1) // not mass-convertible → skipped
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 100)
+    }
+
+    @Test("Exact-unit (count) match decrements")
+    func exactUnitMatch() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "caps", initial: 30)
+        logDose(ctx, amount: 2, unit: "caps", at: 1)
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 28)
+    }
+
+    // MARK: - Salt matching
+
+    @Test("Strict salt match: wrong-form dose is not counted")
+    func strictSaltMatch() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", saltForm: "Glycinate", initial: 100)
+        logDose(ctx, amount: 20, saltForm: "Citrate", at: 1) // different salt
+        logDose(ctx, amount: 10, saltForm: nil, at: 2) // base form
+        logDose(ctx, amount: 5, saltForm: "Glycinate", at: 3) // matches
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 95)
+    }
+
+    // MARK: - trackingStart cutoff
+
+    @Test("Doses before trackingStart don't count")
+    func preTrackingExcluded() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", trackingStart: now, initial: 100)
+        logDose(ctx, amount: 40, at: -2) // before tracking start
+        logDose(ctx, amount: 10, at: 2) // after
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 90)
+    }
+
+    // MARK: - Back-dated reorder
+
+    @Test("Back-dated dose is replayed in date order")
+    func backDatedReplay() throws {
+        let ctx = try makeContext()
+        // initial 100 @0h, restock +50 @10h, with a dose back-dated to +5h —
+        // between the two manual events. Date-sorted replay: 100 → 70 → 120.
+        let item = makeItem(ctx, unit: "mg", initial: 100)
+        item.manualEvents.append(ManualEvent(
+            kind: .restock, amount: 50, date: now.addingTimeInterval(10 * 3_600),
+        ))
+        logDose(ctx, amount: 30, at: 5)
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 120)
+    }
+
+    // MARK: - Edit/delete reflected
+
+    @Test("Deleting a dose restores stock on re-query")
+    func deleteReflected() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 100)
+        let dose = logDose(ctx, amount: 25, at: 1)
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 75)
+        ctx.delete(dose)
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 100)
+    }
+
+    @Test("Editing a dose amount is reflected on re-query")
+    func editReflected() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 100)
+        let dose = logDose(ctx, amount: 25, at: 1)
+        dose.amount = 40
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 60)
+    }
+
+    // MARK: - Cache
+
+    @Test("recompute refreshes the currentQuantity cache")
+    func recomputeCache() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 100)
+        #expect(item.currentQuantity == 0) // not yet computed
+        logDose(ctx, amount: 30, at: 1)
+        InventoryService.recompute(item, in: ctx)
+        #expect(item.currentQuantity == 70)
+    }
+
+    @Test("recomputeAll touches every tracked item")
+    func recomputeAll() throws {
+        let ctx = try makeContext()
+        let a = makeItem(ctx, unit: "mg", initial: 100)
+        let b = makeItem(ctx, substance: "ZZOther", unit: "mg", initial: 50)
+        logDose(ctx, amount: 10, at: 1)
+        logDose(ctx, substance: "ZZOther", amount: 5, at: 1)
+        InventoryService.recomputeAll(in: ctx)
+        #expect(a.currentQuantity == 90)
+        #expect(b.currentQuantity == 45)
+    }
+
+    // MARK: - find / create
+
+    @Test("find matches case-insensitively on substance + strict salt")
+    func findMatch() throws {
+        let ctx = try makeContext()
+        _ = makeItem(ctx, unit: "mg", saltForm: "Glycinate")
+        #expect(InventoryService.find(substance: drug.lowercased(), saltForm: "Glycinate", in: ctx) != nil)
+        #expect(InventoryService.find(substance: drug, saltForm: nil, in: ctx) == nil)
+    }
+
+    @Test("create with setBaseline pins the post-initial total")
+    func createSetsBaseline() throws {
+        let ctx = try makeContext()
+        let item = InventoryService.create(
+            substance: drug, saltForm: nil, unit: "g", initial: 5,
+            threshold: nil, setBaseline: true, in: ctx,
+        )
+        #expect(item.baselineQuantity == 5)
+        #expect(item.manualEvents.first?.setsBaseline == true)
+    }
+
+    // MARK: - Baseline
+
+    @Test("setBaseline with 0 disables the bar")
+    func baselineZeroDisables() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 100)
+        InventoryService.setBaseline(item, value: 200, in: ctx)
+        #expect(item.baselineQuantity == 200)
+        InventoryService.setBaseline(item, value: 0, in: ctx)
+        #expect(item.baselineQuantity == nil)
+    }
+
+    @Test("restock with setBaseline captures the new full level")
+    func restockSetsBaseline() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 20)
+        InventoryService.restock(item, amount: 80, note: "refill", setBaseline: true, in: ctx)
+        #expect(item.currentQuantity == 100)
+        #expect(item.baselineQuantity == 100)
+    }
+
+    // MARK: - correctTo
+
+    @Test("correctTo lands the exact amount via a signed adjustment")
+    func correctToExact() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 100)
+        logDose(ctx, amount: 30, at: 1) // -> 70
+        InventoryService.correctTo(item, exact: 65, note: "recount", in: ctx)
+        #expect(InventoryMath.quantity(for: item, in: ctx) == 65)
+        #expect(item.currentQuantity == 65)
+    }
+
+    // MARK: - Unit change
+
+    @Test("changeUnit converts events + derived fields within the mass family")
+    func unitChangeConverts() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "g", initial: 5)
+        InventoryService.setBaseline(item, value: 5, in: ctx)
+        item.lowStockThreshold = 1
+        InventoryService.setDoseSize(item, value: 0.2)
+
+        InventoryService.changeUnit(item, to: "mg", in: ctx)
+
+        #expect(item.unit == "mg")
+        #expect(item.baselineQuantity == 5_000)
+        #expect(item.lowStockThreshold == 1_000)
+        #expect(item.doseSize == 200)
+        #expect(item.currentQuantity == 5_000) // 5 g -> 5000 mg
+    }
+
+    @Test("changeUnit to a non-convertible unit clears derived fields")
+    func unitChangeClears() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 100)
+        InventoryService.setBaseline(item, value: 200, in: ctx)
+        item.lowStockThreshold = 10
+        InventoryService.setDoseSize(item, value: 5)
+
+        InventoryService.changeUnit(item, to: "mL", in: ctx)
+
+        #expect(item.unit == "mL")
+        #expect(item.baselineQuantity == nil)
+        #expect(item.lowStockThreshold == nil)
+        #expect(item.doseSize == nil)
+    }
+
+    // MARK: - doses left
+
+    @Test("dosesLeft only when a dose size is set")
+    func dosesLeftGating() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", initial: 100)
+        InventoryService.recompute(item, in: ctx)
+        #expect(InventoryMath.dosesLeft(for: item) == nil) // no doseSize
+        InventoryService.setDoseSize(item, value: 30)
+        #expect(InventoryMath.dosesLeft(for: item) == 3) // floor(100 / 30)
+    }
+
+    // MARK: - Run-out gate
+
+    @Test("runOut requires at least 5 of the last 7 days dosed")
+    func runOutGateOff() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", trackingStart: now.addingTimeInterval(-30 * 86_400), initial: 100)
+        // Only 3 distinct days in the last week.
+        for day in 1...3 {
+            logDose(ctx, amount: 10, at: Double(-day) * 24)
+        }
+        InventoryService.recompute(item, in: ctx)
+        #expect(InventoryMath.runOut(for: item, in: ctx, now: now) == nil)
+    }
+
+    @Test("runOut computes daily average and days left when the gate passes")
+    func runOutGateOn() throws {
+        let ctx = try makeContext()
+        let item = makeItem(ctx, unit: "mg", trackingStart: now.addingTimeInterval(-30 * 86_400), initial: 700)
+        // 7 distinct days, 10 mg each -> 70 mg consumed -> dailyAvg 10.
+        for day in 0...6 {
+            logDose(ctx, amount: 10, at: Double(-day) * 24 - 1)
+        }
+        InventoryService.recompute(item, in: ctx)
+        let result = try #require(InventoryMath.runOut(for: item, in: ctx, now: now))
+        #expect(result.dailyAvg == 10)
+        // current = 700 - 70 = 630 -> 63 days left.
+        #expect(result.daysLeft == 63)
+    }
+}

--- a/PiruWidget/InventoryWidget.swift
+++ b/PiruWidget/InventoryWidget.swift
@@ -1,0 +1,172 @@
+import SwiftData
+import SwiftUI
+import WidgetKit
+
+// MARK: - Inventory Widget (read-only)
+
+/// A glanceable, read-only stock display. Reads the denormalized
+/// ``InventoryItem/currentQuantity`` cache the app keeps fresh (no derivation,
+/// no writes) and shows the highest-priority items: out → low → recently used.
+struct InventoryWidget: Widget {
+    let kind = "InventoryWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: InventoryProvider()) { entry in
+            InventoryWidgetView(entry: entry)
+                .containerBackground(for: .widget) {
+                    WidgetBackground()
+                }
+        }
+        .configurationDisplayName("Inventory")
+        .description("See how much you have left of what you track.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+// MARK: - Entry
+
+struct InventoryEntry: TimelineEntry {
+    let date: Date
+    let items: [Item]
+
+    struct Item: Identifiable {
+        let id: UUID
+        let name: String
+        let quantity: Double
+        let unit: String
+        let colorHex: String
+        let isOut: Bool
+        let isLow: Bool
+    }
+}
+
+// MARK: - Provider
+
+struct InventoryProvider: TimelineProvider {
+    func placeholder(in _: Context) -> InventoryEntry {
+        InventoryEntry(date: .now, items: [
+            .init(id: UUID(), name: "Ketamine", quantity: 4.8, unit: "g", colorHex: "78A6F5", isOut: false, isLow: false),
+            .init(id: UUID(), name: "Magnesium", quantity: 6, unit: "caps", colorHex: "8CD98C", isOut: false, isLow: true),
+        ])
+    }
+
+    func getSnapshot(in _: Context, completion: @escaping (InventoryEntry) -> Void) {
+        completion(fetchEntry())
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<InventoryEntry>) -> Void) {
+        // Stock only changes from in-app actions, which reload the timeline; a
+        // daily fallback refresh keeps a long-idle widget from going stale.
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 12, to: .now)!
+        completion(Timeline(entries: [fetchEntry()], policy: .after(nextUpdate)))
+    }
+
+    private func fetchEntry() -> InventoryEntry {
+        guard let container = WidgetStoreAccess.makeContainer() else {
+            return InventoryEntry(date: .now, items: [])
+        }
+        let context = ModelContext(container)
+        let items = (try? context.fetch(FetchDescriptor<InventoryItem>())) ?? []
+        let hexMap = ((try? context.fetch(FetchDescriptor<SubstanceColor>())) ?? []).hexColorMap
+
+        func isOut(_ item: InventoryItem) -> Bool { item.currentQuantity <= 0 }
+        func isLow(_ item: InventoryItem) -> Bool {
+            guard let t = item.lowStockThreshold, t > 0 else { return false }
+            return item.currentQuantity <= t
+        }
+        func priority(_ item: InventoryItem) -> Int {
+            if isOut(item) { return 0 }
+            if isLow(item) { return 1 }
+            return 2
+        }
+        func lastActivity(_ item: InventoryItem) -> Date {
+            item.manualEvents.map(\.date).max() ?? item.createdAt
+        }
+
+        let sorted = items.sorted {
+            if priority($0) != priority($1) { return priority($0) < priority($1) }
+            return lastActivity($0) > lastActivity($1)
+        }
+
+        return InventoryEntry(
+            date: .now,
+            items: sorted.prefix(4).map { item in
+                InventoryEntry.Item(
+                    id: item.id,
+                    name: item.substance,
+                    quantity: item.currentQuantity,
+                    unit: item.unit,
+                    colorHex: SubstancePalette.hex(for: item.substance, hexMap: hexMap),
+                    isOut: isOut(item),
+                    isLow: isLow(item),
+                )
+            },
+        )
+    }
+}
+
+// MARK: - View
+
+struct InventoryWidgetView: View {
+    let entry: InventoryEntry
+
+    @Environment(\.widgetFamily) var family
+
+    private var rowLimit: Int { family == .systemMedium ? 4 : 3 }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Inventory")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Image(systemName: "shippingbox")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if entry.items.isEmpty {
+                Spacer(minLength: 0)
+                Text("Nothing tracked")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+            } else {
+                ForEach(entry.items.prefix(rowLimit)) { item in
+                    row(item)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(2)
+    }
+
+    private func row(_ item: InventoryEntry.Item) -> some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(Color(hex: item.colorHex))
+                .frame(width: 7, height: 7)
+            Text(item.name)
+                .font(.caption)
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            Text(amountText(item))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(amountColor(item))
+                .lineLimit(1)
+        }
+    }
+
+    private func amountText(_ item: InventoryEntry.Item) -> String {
+        if item.isOut { return String(localized: "Out") }
+        return "\(item.quantity.doseFormatted) \(item.unit)"
+    }
+
+    /// Color carries meaning only for Low/Out; a healthy supply reads neutral.
+    private func amountColor(_ item: InventoryEntry.Item) -> Color {
+        if item.isOut { return .red }
+        if item.isLow { return .orange }
+        return .primary
+    }
+}

--- a/PiruWidget/Localizable.xcstrings
+++ b/PiruWidget/Localizable.xcstrings
@@ -413,6 +413,9 @@
         }
       }
     },
+    "Inventory" : {
+
+    },
     "Last Dose" : {
       "localizations" : {
         "zh-Hans" : {
@@ -510,6 +513,9 @@
         }
       }
     },
+    "Nothing tracked" : {
+
+    },
     "Offset" : {
       "localizations" : {
         "zh-Hans" : {
@@ -574,6 +580,9 @@
         }
       }
     },
+    "Out" : {
+
+    },
     "Peak" : {
       "localizations" : {
         "zh-Hans" : {
@@ -605,6 +614,9 @@
           }
         }
       }
+    },
+    "See how much you have left of what you track." : {
+
     },
     "See what you've taken today at a glance." : {
       "extractionState" : "stale",

--- a/PiruWidget/PiruWidgetBundle.swift
+++ b/PiruWidget/PiruWidgetBundle.swift
@@ -6,5 +6,6 @@ struct PiruWidgetBundle: WidgetBundle {
     var body: some Widget {
         TodaySummaryWidget()
         RecentDoseWidget()
+        InventoryWidget()
     }
 }

--- a/PiruWidget/WidgetStoreAccess.swift
+++ b/PiruWidget/WidgetStoreAccess.swift
@@ -26,7 +26,7 @@ enum WidgetStoreAccess {
         return try? ModelContainer(
             for: DoseEntry.self, SubstanceColor.self, UserColor.self,
             DailyDoseItem.self, FavoriteSubstance.self, QuickLogDose.self, Session.self,
-            DoseRoutine.self,
+            DoseRoutine.self, InventoryItem.self,
             configurations: config,
         )
     }

--- a/Shared/InventoryItem.swift
+++ b/Shared/InventoryItem.swift
@@ -1,0 +1,136 @@
+import Foundation
+import SwiftData
+
+// MARK: - Manual Event
+
+/// A user-entered change to an inventory item's stock: the initial amount, a
+/// restock, or a manual correction. Plain value type — **not** a `@Model`.
+///
+/// Manual events are embedded as a JSON array inside
+/// ``InventoryItem/restocksData`` (mirroring ``DailyDoseItem/frequencyDays``)
+/// rather than living in a separate ledger model: they are few, never queried
+/// independently, and only ever read alongside their item. Dose *consumption* is
+/// not stored here at all — it is derived on read from the `DoseEntry` log.
+struct ManualEvent: Codable, Identifiable, Hashable {
+    /// Stable identity, used to union events idempotently on re-import.
+    var id: UUID = UUID()
+    /// What kind of manual change this represents.
+    var kind: Kind = .restock
+    /// Signed amount in the item's unit. `initial`/`restock` are positive; an
+    /// `adjustment` is signed (a correction up or down).
+    var amount: Double = 0
+    /// When the change happened; drives the date-sorted replay.
+    var date: Date = .now
+    /// Optional free-form note (e.g. "pharmacy refill").
+    var note: String? = nil
+    /// Provenance flag: this event pinned the item's baseline. Purely
+    /// informational — the UI shows the baseline as a fraction, not a ledger tag.
+    var setsBaseline: Bool = false
+
+    enum Kind: String, Codable {
+        case initial
+        case restock
+        case adjustment
+    }
+}
+
+// MARK: - Inventory Item
+
+/// An opt-in stock record for one `(substance, salt/form)` pair.
+///
+/// SwiftData `@Model` shared across the main Piru app, the Home Screen widget
+/// (`PiruWidget`), and the Lock Screen Live Activity extension
+/// (`PiruLiveActivityExtension`).
+///
+/// ## Derived, not stored
+/// The current amount on hand is **not** a running tally. It is replayed on read
+/// from two sources by ``InventoryMath``:
+/// 1. The manual side — ``manualEvents`` (restocks / corrections / initial),
+///    persisted here as embedded JSON.
+/// 2. The consumption side — a `SELECT` over the `DoseEntry` rows the app already
+///    keeps, filtered by substance, salt, and `timestamp >= trackingStart`.
+///
+/// Because consumption is a fresh projection of the dose log, editing or deleting
+/// a dose is reflected automatically with no sync code, and imported doses count
+/// exactly like typed ones. ``currentQuantity`` is only a denormalized **cache**
+/// of that computation for cheap badge/widget reads; it self-heals on the next
+/// `recompute`.
+///
+/// ## Identity
+/// Mirrors `FavoriteSubstance` / `SubstanceColor`: ``substance`` is a
+/// case-insensitive `String` and ``saltForm`` is the second axis. No
+/// `@Attribute(.unique)` — the `(substance, saltForm)` pair is the key and we
+/// match in code (avoids unique-constraint / CloudKit edges).
+///
+/// ## Schema Migration Note
+/// Every persisted property has a default value, so adding this model — and any
+/// future field on it — is an additive lightweight migration with no
+/// `SchemaMigrationPlan` (see `StoreRecovery.swift`).
+@Model
+final class InventoryItem {
+    /// Stable identity for routing (sheets, deep links).
+    var id: UUID = UUID()
+    /// Canonical substance name; matched case-insensitively against `DoseEntry`.
+    var substance: String = ""
+    /// Salt/form variant; `nil` means base/freebase. Matched strictly.
+    var saltForm: String? = nil
+    /// Base unit the stock is measured in (e.g. `"mg"`, `"mL"`, `"caps"`).
+    var unit: String = "mg"
+    /// Doses on/after this instant count against stock; earlier ones do not.
+    var trackingStart: Date = Date.now
+    /// Opt-in low-stock alert level, in ``unit``. `nil` = no alert.
+    var lowStockThreshold: Double? = nil
+    /// De-dupe flag for the low-stock notification; reset when stock rises back
+    /// above the threshold (e.g. on restock).
+    var lowStockNotified: Bool = false
+    /// Amount that reads as 100% for the supply bar, in ``unit``. `nil` or `0`
+    /// hides the bar (see the Baseline section of the spec).
+    var baselineQuantity: Double? = nil
+    /// "Single dose" in ``unit``, powering "~N doses left". Optional, **not**
+    /// prefilled; `nil` or `0` hides the doses-left value.
+    var doseSize: Double? = nil
+    /// Cache of ``InventoryMath/quantity(for:in:)`` for cheap badge/widget reads.
+    /// Pure-derived, so a stale value self-heals on the next recompute.
+    var currentQuantity: Double = 0
+    /// JSON-encoded backing storage for ``manualEvents``. Prefer the accessor.
+    var restocksData: Data = Data()
+    /// When the user started tracking this item.
+    var createdAt: Date = Date.now
+
+    /// The manual side of the ledger, decoded from ``restocksData``.
+    ///
+    /// Backed by a `Data` column (JSON) for the same reason
+    /// ``DailyDoseItem/frequencyDays`` is: arrays of value types are awkward to
+    /// model across SwiftData and the extension targets, and this set is small
+    /// and read-mostly.
+    var manualEvents: [ManualEvent] {
+        get { (try? JSONDecoder().decode([ManualEvent].self, from: restocksData)) ?? [] }
+        set { restocksData = (try? JSONEncoder().encode(newValue)) ?? Data() }
+    }
+
+    init(
+        id: UUID = UUID(),
+        substance: String = "",
+        saltForm: String? = nil,
+        unit: String = "mg",
+        trackingStart: Date = .now,
+        lowStockThreshold: Double? = nil,
+        baselineQuantity: Double? = nil,
+        doseSize: Double? = nil,
+        manualEvents: [ManualEvent] = [],
+        createdAt: Date = .now,
+    ) {
+        self.id = id
+        self.substance = substance
+        self.saltForm = saltForm
+        self.unit = unit
+        self.trackingStart = trackingStart
+        self.lowStockThreshold = lowStockThreshold
+        self.lowStockNotified = false
+        self.baselineQuantity = baselineQuantity
+        self.doseSize = doseSize
+        self.currentQuantity = 0
+        self.restocksData = (try? JSONEncoder().encode(manualEvents)) ?? Data()
+        self.createdAt = createdAt
+    }
+}


### PR DESCRIPTION
## Overview

Opt-in **substance inventory tracking**, keyed by `(substance, salt/form)`. The current amount is **derived, not stored**: stock = `replay(manual events ∪ doses logged since trackingStart, converted + floored)`. Editing or deleting a dose reflects automatically — **no hooks in any dose create/edit/delete path**. Imported doses count (required for backup fidelity).

Spec: `Specs/substance-inventory-tracking.{md,html}`.

## What's included

- **Model** — `Shared/InventoryItem.swift` (`@Model` + embedded Codable `ManualEvent`, mirroring `DailyDoseItem.frequencyDays`); registered in `StoreRecovery.models` + `WidgetStoreAccess`. All fields defaulted → additive lightweight migration.
- **Derivation / mutations** — `Piru/Data/InventoryService.swift`: `InventoryMath` (floored replay, mass-family + exact-unit conversion, rolling-7-day run-out gated ≥5/7 days, doses-left) and `InventoryService` (find/create/restock/correctTo/setBaseline/setDoseSize/changeUnit/recompute). `currentQuantity` is a self-healing cache.
- **Cache + notifications** — `recomputeAll` wired at post-log/delete sites (QuickLog, EntryForm, EntryDetail) + app foreground/launch; low-stock alert via `DoseNotificationManager` (de-duped, silent on bulk import).
- **Manager UI** (Tools → Inventory) — grouped list + summary card, item detail (run-out + basis + ⓘ, supply bar, merged dose/manual history with swipe-to-delete), add/restock + edit sheets (✕/✓ nav). Add form uses the shared `SubstanceSearchField` autocomplete; first-tracked substances get a persisted color so they're editable in the colors menu.
- **Secondary surfaces** — substance-detail stock card (Track/Restock pills, bar, run-out, unit-mismatch hint); passive quick-log supply hint; read-only `InventoryWidget` (small/medium).
- **Export / import / backup** — rides Piru-native JSON + encrypted backup (**omitted from PsyLog**); merge by `(substance, salt)`, union events by id (idempotent), earliest `trackingStart`, recompute on import. Added to `deleteAll`; `DataStorageView` count row + footer.

## Display vs. storage

Substance names render via `displayTitle` (e.g. "2-Br-DCK") for consistency with quick-log/journal, while **stored canonical** for dose matching.

## Tests

`PiruTests/InventoryTests.swift` (23) + `PiruTests/InventoryExportTests.swift` (4): floored replay/forgive, convert vs mismatch, strict salt, trackingStart cutoff, back-dated reorder, edit/delete reflection, baseline 0-disable + clamp, unit-change convert/clear, run-out gate, doses-left gating, export round-trip / idempotent re-import / merge / PsyLog omission. Full app builds across all targets.

## Follow-up

zh-Hans / zh-Hant translations (Phase 6): all strings use localizable APIs and English is extracted, but translations aren't in `translate_catalog.py` yet — they render English for Chinese users until added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)